### PR TITLE
Ensure worker message subscriptions mount safely

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ function App() {
 
     window.worker = worker;
 
-    const { onMessage, sendData } = useWorkerClient(window.worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(window.worker);
 
     const [readyToGo, setReadyToGo] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
@@ -35,39 +35,52 @@ function App() {
         };
     }, []);
 
-    onMessage('initialized', async (event) => {
-        let saveString = window.localStorage.getItem('idlemanceryV2Reworked');
-        if (window.electron?.loadFromCloud()) {
-            saveString = await window.electron.loadFromCloud();
-        }
-        if(!saveString) {
-            saveString = window.localStorage.getItem('idlemanceryV2Reworked');
-        }
-        if(!saveString) {
-            sendData('reset-game', {});
-            return
-        }
-        sendData('load-game', JSON.parse(saveString));
-    });
+    useEffect(() => {
+        const handleInitialized = async () => {
+            let saveString = window.localStorage.getItem('idlemanceryV2Reworked');
+            if (window.electron?.loadFromCloud()) {
+                saveString = await window.electron.loadFromCloud();
+            }
+            if(!saveString) {
+                saveString = window.localStorage.getItem('idlemanceryV2Reworked');
+            }
+            if(!saveString) {
+                sendData('reset-game', {});
+                return;
+            }
+            sendData('load-game', JSON.parse(saveString));
+        };
 
-    onMessage('loading', (event) => {
-        setReadyToGo(false);
-    });
+        const handleLoading = () => {
+            setReadyToGo(false);
+        };
 
-    onMessage('loaded', (pl) => {
-        // Request and apply sound valumes here
-        setReadyToGo(true);
-        if(pl.isReset) {
-            setOpenedTab('actions');
-        }
-    })
+        const handleLoaded = (pl) => {
+            setReadyToGo(true);
+            if(pl.isReset) {
+                setOpenedTab('actions');
+            }
+        };
 
-    onMessage('save-game', async (data) => {
-        window.localStorage.setItem('idlemanceryV2Reworked', JSON.stringify(data));
-        if (window.electron?.saveToCloud) {
-            await window.electron.saveToCloud(data); // При збереженні
-        }
-    })
+        const handleSaveGame = async (data) => {
+            window.localStorage.setItem('idlemanceryV2Reworked', JSON.stringify(data));
+            if (window.electron?.saveToCloud) {
+                await window.electron.saveToCloud(data); // При збереженні
+            }
+        };
+
+        onMessage('initialized', handleInitialized);
+        onMessage('loading', handleLoading);
+        onMessage('loaded', handleLoaded);
+        onMessage('save-game', handleSaveGame);
+
+        return () => {
+            removeMessage('initialized');
+            removeMessage('loading');
+            removeMessage('loaded');
+            removeMessage('save-game');
+        };
+    }, [onMessage, removeMessage, sendData, setOpenedTab]);
 
     useEffect(() => {
         if(readyToGo) {

--- a/src/components/layout/banked-time-wrap.jsx
+++ b/src/components/layout/banked-time-wrap.jsx
@@ -8,7 +8,7 @@ import {useAppContext} from "../../context/ui-context";
 export const BankedTimeWrap = () => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { togglePopup } = useAppContext();
     const [mageData, setMageData] = useState({});
 
@@ -26,9 +26,17 @@ export const BankedTimeWrap = () => {
         sendData('toggle-speedup', {});
     }
 
-    onMessage('mage-data-banked', (data) => {
-        setMageData(data);
-    });
+    useEffect(() => {
+        const handleMageData = (data) => {
+            setMageData(data);
+        };
+
+        onMessage('mage-data-banked', handleMageData);
+
+        return () => {
+            removeMessage('mage-data-banked');
+        };
+    }, [onMessage, removeMessage]);
 
     return (
         <div className={'banked-time-wrap'}>

--- a/src/components/layout/main-menu.jsx
+++ b/src/components/layout/main-menu.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useCallback } from "react";
 import WorkerContext from "../../context/worker-context";
 import { useWorkerClient } from "../../general/client";
 import { useAppContext } from "../../context/ui-context";
@@ -7,7 +7,7 @@ import {useTutorial} from "../../context/tutorial-context";
 
 export const MainMenu = () => {
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { openedTab, setOpenedTab, togglePopup } = useAppContext();
     const [unlocks, setUnlocksData] = useState({});
     const [newUnlocks, setNewUnlocks] = useState({});
@@ -41,9 +41,9 @@ export const MainMenu = () => {
         }
     }
 
-    const openTab = (id) => {
+    const openTab = useCallback((id) => {
         setOpenedTab(id);
-    }
+    }, [setOpenedTab]);
 
     useEffect(() => {
         const isEditableTarget = (el) => {
@@ -87,21 +87,31 @@ export const MainMenu = () => {
         return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
     }, [hotkeys]);
 
-    onMessage('all-hotkeys-all', payload => {
-        // console.log('Received AllHotkeys: ', payload);
-        setHotkeys(payload);
-    })
+    useEffect(() => {
+        const handleAllHotkeys = (payload) => {
+            setHotkeys(payload);
+        };
 
-    onMessage('hotkey-triggered', (hotkey) => {
-        if (hotkey.action === 'selectTab') {
-            openTab(hotkey.param);
-        } else if (hotkey.action === 'openQuickAccess') {
-            togglePopup('quick-access');
-        }
-    })
+        const handleHotkeyTriggered = (hotkey) => {
+            if (hotkey.action === 'selectTab') {
+                openTab(hotkey.param);
+            } else if (hotkey.action === 'openQuickAccess') {
+                togglePopup('quick-access');
+            }
+        };
 
-    onMessage('unlocks-main-menu', setUnlocksData);
-    onMessage('new-unlocks-notifications-main-menu', setNewUnlocks);
+        onMessage('all-hotkeys-all', handleAllHotkeys);
+        onMessage('hotkey-triggered', handleHotkeyTriggered);
+        onMessage('unlocks-main-menu', setUnlocksData);
+        onMessage('new-unlocks-notifications-main-menu', setNewUnlocks);
+
+        return () => {
+            removeMessage('all-hotkeys-all');
+            removeMessage('hotkey-triggered');
+            removeMessage('unlocks-main-menu');
+            removeMessage('new-unlocks-notifications-main-menu');
+        };
+    }, [onMessage, removeMessage, openTab, togglePopup, setUnlocksData, setNewUnlocks]);
 
     return (
         <div className={'left-most'}>

--- a/src/components/layout/personage-circle.jsx
+++ b/src/components/layout/personage-circle.jsx
@@ -8,7 +8,7 @@ import {formatInt, formatValue, secondsToString} from "../../general/utils/strin
 
 export const PersonageCircle = () => {
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { togglePopup } = useAppContext();
     const [mageData, setMageData] = useState({});
     const [settings, setSettings] = useState({});
@@ -30,11 +30,19 @@ export const PersonageCircle = () => {
         window.notation = settings.notation;
     }, [settings?.notation]);
 
-    onMessage('mage-data-xpbar', (data) => {
-        const {settings, ...mage} = data;
-        setMageData(mage);
-        setSettings(settings);
-    });
+    useEffect(() => {
+        const handleMageData = (data) => {
+            const {settings: settingsData, ...mage} = data;
+            setMageData(mage);
+            setSettings(settingsData);
+        };
+
+        onMessage('mage-data-xpbar', handleMageData);
+
+        return () => {
+            removeMessage('mage-data-xpbar');
+        };
+    }, [onMessage, removeMessage]);
 
     return mageData ? (
         <div className={'mage-wrap flex-container'} ref={elementRef}>

--- a/src/components/layout/personage-level.jsx
+++ b/src/components/layout/personage-level.jsx
@@ -8,7 +8,7 @@ import { formatInt, secondsToString } from "../../general/utils/strings";
 
 export const PersonageLevel = () => {
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { togglePopup } = useAppContext();
     const [mageData, setMageData] = useState({});
     const elementRef = useRef(null);
@@ -17,7 +17,13 @@ export const PersonageLevel = () => {
         sendData('query-mage-data', {});
     }, []);
 
-    onMessage('mage-data', setMageData);
+    useEffect(() => {
+        onMessage('mage-data', setMageData);
+
+        return () => {
+            removeMessage('mage-data');
+        };
+    }, [onMessage, removeMessage]);
 
     return mageData ? (
         <div className={'mage-wrap flex-container'} ref={elementRef}>

--- a/src/components/main.jsx
+++ b/src/components/main.jsx
@@ -29,7 +29,7 @@ export const Main = ({ readyToGo, isLoading }) => {
 export const LoadedMain = () => {
     const worker = useContext(WorkerContext);
 
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { startTutorialById, stopTutorial, setStepIndex } = useTutorial();
     const { initializeVolumes } = useSound();
 
@@ -50,32 +50,34 @@ export const LoadedMain = () => {
         // startTutorial();
     }, [])
 
-    onMessage('tour_status', payload => {
-        if(!payload?.isComplete && payload.isAllowed) {
-            startTutorialById('initial');
-            if(payload?.skipStep) {
-                setStepIndex(payload.skipStep);
+    useEffect(() => {
+        const handleTourStatus = (payload) => {
+            if(!payload?.isComplete && payload.isAllowed) {
+                startTutorialById('initial');
+                if(payload?.skipStep) {
+                    setStepIndex(payload.skipStep);
+                }
             }
-        }
-    })
+        };
 
-    onMessage('settings', (s) => {
-        // Apply Electron zoom if available
-        const percent = Number(s?.uiScalePercent ?? 100);
-        const factor = Math.max(0.5, Math.min(3, (Number.isFinite(percent) ? percent : 100) / 100));
-        if (window?.zoomAPI?.set) {
-            window.zoomAPI.set(factor);
-        }
-    })
+        const applyZoom = (s) => {
+            const percent = Number(s?.uiScalePercent ?? 100);
+            const factor = Math.max(0.5, Math.min(3, (Number.isFinite(percent) ? percent : 100) / 100));
+            if (window?.zoomAPI?.set) {
+                window.zoomAPI.set(factor);
+            }
+        };
 
-    // Apply zoom when settings are received with prefix label from the early request
-    onMessage('settings-ui', (s) => {
-        const percent = Number(s?.uiScalePercent ?? 100);
-        const factor = Math.max(0.5, Math.min(3, (Number.isFinite(percent) ? percent : 100) / 100));
-        if (window?.zoomAPI?.set) {
-            window.zoomAPI.set(factor);
-        }
-    })
+        onMessage('tour_status', handleTourStatus);
+        onMessage('settings', applyZoom);
+        onMessage('settings-ui', applyZoom);
+
+        return () => {
+            removeMessage('tour_status');
+            removeMessage('settings');
+            removeMessage('settings-ui');
+        };
+    }, [onMessage, removeMessage, startTutorialById, setStepIndex]);
 
     return (<div className={'page-wrap'}>
         <Content />

--- a/src/components/settings/automation-settings.jsx
+++ b/src/components/settings/automation-settings.jsx
@@ -9,7 +9,7 @@ export const AutomationsSettings = () => {
 
     const worker = useContext(WorkerContext);
 
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
 
     const [resources, setResources] = useState(null);
 
@@ -21,13 +21,23 @@ export const AutomationsSettings = () => {
 
     }, [])
 
-    onMessage('all-resources-automation', (payload) => {
-        setResources(payload);
-    })
+    useEffect(() => {
+        const handleResources = (payload) => {
+            setResources(payload);
+        };
 
-    onMessage('unlocks', (unlocks) => {
-        setUnlocksData(unlocks);
-    })
+        const handleUnlocks = (nextUnlocks) => {
+            setUnlocksData(nextUnlocks);
+        };
+
+        onMessage('all-resources-automation', handleResources);
+        onMessage('unlocks', handleUnlocks);
+
+        return () => {
+            removeMessage('all-resources-automation');
+            removeMessage('unlocks');
+        };
+    }, [onMessage, removeMessage]);
 
     if(!unlocks.automations || (!unlocks.actionLists && !unlocks.inventory && !unlocks.spellbook)) {
         return (<div className={'inner-settings-wrap automations-wrap'}>
@@ -54,7 +64,7 @@ export const AutomationsSettings = () => {
 export const ActionsAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(true);
 
@@ -62,9 +72,17 @@ export const ActionsAutomations = ({ resources }) => {
         sendData('query-actions-lists', { filterAutomated: true })
     }, []);
 
-    onMessage('actions-lists', (data) => {
-        setAutomations(data);
-    })
+    useEffect(() => {
+        const handleActionsLists = (data) => {
+            setAutomations(data);
+        };
+
+        onMessage('actions-lists', handleActionsLists);
+
+        return () => {
+            removeMessage('actions-lists');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveAction = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -124,7 +142,7 @@ export const AutomatedAction = ({ auto, resources, onSaveAction }) => {
 export const PurchaseAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(false);
 
@@ -132,11 +150,19 @@ export const PurchaseAutomations = ({ resources }) => {
         sendData('query-items-resources-data', { filterAutomatedPurchase: true, includeAutomations: true, prefix: 'autopurchase' })
     }, []);
 
-    onMessage('items-resources-data-autopurchase', (data) => {
-        if(data.payload.filterAutomatedPurchase) {
-            setAutomations(data.available);
-        }
-    })
+    useEffect(() => {
+        const handleAutoPurchase = (data) => {
+            if(data.payload.filterAutomatedPurchase) {
+                setAutomations(data.available);
+            }
+        };
+
+        onMessage('items-resources-data-autopurchase', handleAutoPurchase);
+
+        return () => {
+            removeMessage('items-resources-data-autopurchase');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveConsume = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -192,7 +218,7 @@ export const AutomatedPurchase = ({ auto, resources, onSaveConsume }) => {
 export const ConsumeAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(false);
 
@@ -200,11 +226,19 @@ export const ConsumeAutomations = ({ resources }) => {
         sendData('query-inventory-data', { filterAutomatedConsume: true, includeAutomations: true, prefix: 'autoconsume' })
     }, []);
 
-    onMessage('inventory-data-autoconsume', (data) => {
-        if(data.payload.filterAutomatedConsume) {
-            setAutomations(data.available);
-        }
-    })
+    useEffect(() => {
+        const handleAutoConsume = (data) => {
+            if(data.payload.filterAutomatedConsume) {
+                setAutomations(data.available);
+            }
+        };
+
+        onMessage('inventory-data-autoconsume', handleAutoConsume);
+
+        return () => {
+            removeMessage('inventory-data-autoconsume');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveConsume = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -258,7 +292,7 @@ export const AutomatedConsumption = ({ auto, resources, onSaveConsume }) => {
 export const SellAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(false);
 
@@ -266,11 +300,19 @@ export const SellAutomations = ({ resources }) => {
         sendData('query-inventory-data', { filterAutomatedSell: true, includeAutomations: true, prefix: 'autosell' })
     }, []);
 
-    onMessage('inventory-data-autosell', (data) => {
-        if(data.payload.filterAutomatedSell) {
-            setAutomations(data.available);
-        }
-    })
+    useEffect(() => {
+        const handleAutoSell = (data) => {
+            if(data.payload.filterAutomatedSell) {
+                setAutomations(data.available);
+            }
+        };
+
+        onMessage('inventory-data-autosell', handleAutoSell);
+
+        return () => {
+            removeMessage('inventory-data-autosell');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveSell = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -323,7 +365,7 @@ export const AutomatedSell = ({ auto, resources, onSaveSell }) => {
 export const MapTilesAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(true);
 
@@ -331,9 +373,17 @@ export const MapTilesAutomations = ({ resources }) => {
         sendData('query-map-tile-lists', { filterAutomated: true })
     }, []);
 
-    onMessage('map-tile-lists', (data) => {
-        setAutomations(data.lists);
-    })
+    useEffect(() => {
+        const handleMapTileLists = (data) => {
+            setAutomations(data.lists);
+        };
+
+        onMessage('map-tile-lists', handleMapTileLists);
+
+        return () => {
+            removeMessage('map-tile-lists');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveAction = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -393,7 +443,7 @@ export const AutomatedMapTile = ({ auto, resources, onSaveAction }) => {
 export const CraftingAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(true);
 
@@ -401,9 +451,17 @@ export const CraftingAutomations = ({ resources }) => {
         sendData('query-crafting-lists', { filterAutomated: true, category: 'crafting' })
     }, []);
 
-    onMessage('crafting-lists-crafting', (data) => {
-        setAutomations(data.lists);
-    })
+    useEffect(() => {
+        const handleCraftingLists = (data) => {
+            setAutomations(data.lists);
+        };
+
+        onMessage('crafting-lists-crafting', handleCraftingLists);
+
+        return () => {
+            removeMessage('crafting-lists-crafting');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveAction = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -462,7 +520,7 @@ export const AutomatedCrafting = ({ auto, resources, onSaveAction }) => {
 export const AlchemyAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(true);
 
@@ -470,10 +528,17 @@ export const AlchemyAutomations = ({ resources }) => {
         sendData('query-crafting-lists', { filterAutomated: true, category: 'alchemy' })
     }, []);
 
-    onMessage('crafting-lists-alchemy', (data) => {
-        console.log('automated-crafting: ', data);
-        setAutomations(data.lists);
-    })
+    useEffect(() => {
+        const handleAlchemyLists = (data) => {
+            setAutomations(data.lists);
+        };
+
+        onMessage('crafting-lists-alchemy', handleAlchemyLists);
+
+        return () => {
+            removeMessage('crafting-lists-alchemy');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveAction = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -533,7 +598,7 @@ export const AutomatedAlchemy = ({ auto, resources, onSaveAction }) => {
 export const SpellAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(false);
 
@@ -541,12 +606,17 @@ export const SpellAutomations = ({ resources }) => {
         sendData('query-spell-data', { filterAutomated: true, includeAutomations: true, prefix: 'autocast' })
     }, []);
 
-    onMessage('spell-data-autocast', (data) => {
-        console.log('SPELLS: ', data);
+    useEffect(() => {
+        const handleSpellData = (data) => {
+            setAutomations(data.available);
+        };
 
-        setAutomations(data.available);
+        onMessage('spell-data-autocast', handleSpellData);
 
-    })
+        return () => {
+            removeMessage('spell-data-autocast');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveSpell = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);
@@ -764,7 +834,7 @@ export const AutomatedItem = ({
 export const CoursesAutomations = ({ resources }) => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [automations, setAutomations] = useState([]);
     const [isOpened, setOpened] = useState(true);
 
@@ -772,14 +842,20 @@ export const CoursesAutomations = ({ resources }) => {
         sendData('query-course-data', {});
     }, []);
 
-    onMessage('course-data', (data) => {
-        console.log('data: ', data);
-        // Filter courses with automation enabled
-        const automatedCourses = data.available.filter(course => 
-            course.automation?.isEnabled
-        );
-        setAutomations(automatedCourses);
-    });
+    useEffect(() => {
+        const handleCourseData = (data) => {
+            const automatedCourses = data.available.filter(course =>
+                course.automation?.isEnabled
+            );
+            setAutomations(automatedCourses);
+        };
+
+        onMessage('course-data', handleCourseData);
+
+        return () => {
+            removeMessage('course-data');
+        };
+    }, [onMessage, removeMessage]);
 
     const onSaveCourse = useCallback((id, saveData) => {
         const prev = automations.find(a => a.id === id);

--- a/src/components/settings/interface-settings.jsx
+++ b/src/components/settings/interface-settings.jsx
@@ -69,7 +69,7 @@ const automatedList = [{
 export const InterfaceSettings = () => {
     const worker = useContext(WorkerContext);
 
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
 
     const [unlocks, setUnlocksData] = useState({});
     const [hotkeys, setHotkeys] = useState({});
@@ -106,21 +106,33 @@ export const InterfaceSettings = () => {
         return () => window.removeEventListener("keydown", handleKeyDown);
     }, [editingTab]);
 
-    onMessage("unlocks", (unlocks) => {
-        setUnlocksData(unlocks);
-    });
+    useEffect(() => {
+        const handleUnlocks = (nextUnlocks) => {
+            setUnlocksData(nextUnlocks);
+        };
 
-    onMessage("settings", settings => {
-        setSettings(settings);
-        if (isElectron() && window?.zoomAPI?.set && typeof settings?.uiScalePercent !== 'undefined') {
-            const factor = Math.max(0.5, Math.min(3, Number(settings.uiScalePercent) / 100));
-            window.zoomAPI.set(factor);
-        }
-    })
+        const handleSettings = (nextSettings) => {
+            setSettings(nextSettings);
+            if (isElectron() && window?.zoomAPI?.set && typeof nextSettings?.uiScalePercent !== 'undefined') {
+                const factor = Math.max(0.5, Math.min(3, Number(nextSettings.uiScalePercent) / 100));
+                window.zoomAPI.set(factor);
+            }
+        };
 
-    onMessage("all-hotkeys", (payload) => {
-        setHotkeys(payload);
-    });
+        const handleHotkeys = (payload) => {
+            setHotkeys(payload);
+        };
+
+        onMessage("unlocks", handleUnlocks);
+        onMessage("settings", handleSettings);
+        onMessage("all-hotkeys", handleHotkeys);
+
+        return () => {
+            removeMessage('unlocks');
+            removeMessage('settings');
+            removeMessage('all-hotkeys');
+        };
+    }, [onMessage, removeMessage]);
 
     const setSettingChanged = (key, value) => {
         sendData('set-setting', { key, value });

--- a/src/components/settings/save-settings.jsx
+++ b/src/components/settings/save-settings.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import WorkerContext from "../../context/worker-context";
 import { useWorkerClient } from "../../general/client";
 import {isElectron, quitApp} from "../../general/utils/electron-checks";
@@ -10,7 +10,7 @@ function fromBase64Unicode(str) {
 
 export const SaveSettings = () => {
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { confirm } = useModal();
 
     const [saveString, setSaveString] = useState("");
@@ -77,35 +77,41 @@ export const SaveSettings = () => {
         }
     };
 
-    onMessage("saved-string", ({ type, string }) => {
-        setSaveString(string);
-        if (type === "file") {
-            const blob = new Blob([string], { type: "text/plain;charset=utf-8" });
-            const url = URL.createObjectURL(blob);
+    useEffect(() => {
+        const handleSavedString = ({ type, string }) => {
+            setSaveString(string);
+            if (type === "file") {
+                const blob = new Blob([string], { type: "text/plain;charset=utf-8" });
+                const url = URL.createObjectURL(blob);
 
-            const link = document.createElement("a");
-            link.href = url;
+                const link = document.createElement("a");
+                link.href = url;
 
-            const date = new Date();
-            const year = date.getFullYear();
-            const month = String(date.getMonth() + 1).padStart(2, '0'); // Місяці нумеруються з 0
-            const day = String(date.getDate()).padStart(2, '0');
-            const hours = String(date.getHours()).padStart(2, '0');
-            const minutes = String(date.getMinutes()).padStart(2, '0');
-            const seconds = String(date.getSeconds()).padStart(2, '0');
+                const date = new Date();
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0'); // Місяці нумеруються з 0
+                const day = String(date.getDate()).padStart(2, '0');
+                const hours = String(date.getHours()).padStart(2, '0');
+                const minutes = String(date.getMinutes()).padStart(2, '0');
+                const seconds = String(date.getSeconds()).padStart(2, '0');
 
-            const dateString = `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
-            link.download = `idle_awakening_${dateString}.txt`;
+                const dateString = `${year}-${month}-${day}_${hours}-${minutes}-${seconds}`;
+                link.download = `idle_awakening_${dateString}.txt`;
 
-            // Append to the document to initiate the download in all browsers
-            document.body.appendChild(link);
-            link.click();
+                document.body.appendChild(link);
+                link.click();
 
-            // Clean up
-            document.body.removeChild(link);
-            URL.revokeObjectURL(url);
-        }
-    });
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+            }
+        };
+
+        onMessage("saved-string", handleSavedString);
+
+        return () => {
+            removeMessage('saved-string');
+        };
+    }, [onMessage, removeMessage]);
 
     const resetGame = () => {
         confirm({

--- a/src/components/settings/sound-settings.jsx
+++ b/src/components/settings/sound-settings.jsx
@@ -6,7 +6,7 @@ import {useSound} from "../../context/sounds/sound-context.jsx";
 
 export const SoundSettings = () => {
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { setVolume } = useSound();
 
     const [settings, setSettings] = useState({
@@ -19,9 +19,17 @@ export const SoundSettings = () => {
         sendData("query-settings", { prefix: "sound-settings" });
     }, []);
 
-    onMessage("settings-sound-settings", (newSettings) => {
-        setSettings((prev) => ({ ...prev, ...newSettings }));
-    });
+    useEffect(() => {
+        const handleSettings = (newSettings) => {
+            setSettings((prev) => ({ ...prev, ...newSettings }));
+        };
+
+        onMessage("settings-sound-settings", handleSettings);
+
+        return () => {
+            removeMessage('settings-sound-settings');
+        };
+    }, [onMessage, removeMessage]);
 
     /*const setSettingChanged = (key, value) => {
         setSettings((prev) => ({ ...prev, [key]: value }));

--- a/src/components/shared/achievements.jsx
+++ b/src/components/shared/achievements.jsx
@@ -9,7 +9,7 @@ import {useTutorial} from "../../context/tutorial-context";
 export const ActiveAchievement = () => {
 
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [viewedAchievement, setViewedAchievement] = useState(null);;
     const { activePopup, togglePopup } = useAppContext();
     const { run } = useTutorial();
@@ -25,9 +25,17 @@ export const ActiveAchievement = () => {
         }
     }, [])
 
-    onMessage('achievement-to-view', (data) => {
-        setViewedAchievement(data);
-    })
+    useEffect(() => {
+        const handleAchievement = (data) => {
+            setViewedAchievement(data);
+        };
+
+        onMessage('achievement-to-view', handleAchievement);
+
+        return () => {
+            removeMessage('achievement-to-view');
+        };
+    }, [onMessage, removeMessage]);
 
     useEffect(() => {
         if (run) {
@@ -61,15 +69,21 @@ export const ActiveAchievement = () => {
 
 export const AchievementsCompleted = () => {
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const [achievements, setAchievements] = useState({});
     const [selectedAchievement, setSelectedAchievement] = useState(null);
 
     useEffect(() => {
-        sendData('query-completed-achievements', {})
-    })
+        sendData('query-completed-achievements', {});
+    }, [sendData]);
 
-    onMessage('completed-achievements', setAchievements);
+    useEffect(() => {
+        onMessage('completed-achievements', setAchievements);
+
+        return () => {
+            removeMessage('completed-achievements');
+        };
+    }, [onMessage, removeMessage]);
 
     return <div className={'flex-container achievements-wrap'}>
         <div className={'achievement-list-wrap'}>

--- a/src/components/shared/random-events.jsx
+++ b/src/components/shared/random-events.jsx
@@ -9,17 +9,24 @@ import {TippyWrapper} from "./tippy-wrapper.jsx";
 
 export const RandomEventSnippet = () => {
     const worker = useContext(WorkerContext);
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { togglePopup } = useAppContext();
 
     const [eventData, setEventData] = useState({});
     const [showMore, setShowMore] = useState(false);
     const popupRef = useRef(null); // Reference for the popup
 
-    // Listen for random events data
-    onMessage('random-events-data', (event) => {
-        setEventData(event);
-    });
+    useEffect(() => {
+        const handleEventData = (event) => {
+            setEventData(event);
+        };
+
+        onMessage('random-events-data', handleEventData);
+
+        return () => {
+            removeMessage('random-events-data');
+        };
+    }, [onMessage, removeMessage]);
 
     const openEvent = (eventId) => {
         togglePopup('event', (a) => {
@@ -116,7 +123,7 @@ export const RandomEventPopup = () => {
 
     const worker = useContext(WorkerContext);
 
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
 
     const [eventData, setEventData] = useState({});
 
@@ -129,10 +136,17 @@ export const RandomEventPopup = () => {
         }
     }, [])
 
-    onMessage('random-events-data-popup', (data) => {
-        // console.log('Received data', data);
-        setEventData(data);
-    })
+    useEffect(() => {
+        const handlePopupData = (data) => {
+            setEventData(data);
+        };
+
+        onMessage('random-events-data-popup', handlePopupData);
+
+        return () => {
+            removeMessage('random-events-data-popup');
+        };
+    }, [onMessage, removeMessage]);
 
     const selectOption = (eventId, optionId) => {
         sendData('select-event-option', {eventId, optionId});


### PR DESCRIPTION
## Summary
- wrap worker `onMessage` registrations in `useEffect` with corresponding cleanup across layout and shared components
- update App initialization flow to subscribe to worker events only during mount
- refactor settings automation listeners to avoid re-registering handlers on every render

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691440fff6f88320921d4b83f2c5ee1f)