### PR TITLE
Optimize sidebar stats rendering

### DIFF
--- a/src/components/actions/actions-blades.jsx
+++ b/src/components/actions/actions-blades.jsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useContext, useEffect, useRef, useState} from "react";
+import isEqual from "lodash/isEqual";
 import WorkerContext from "../../context/worker-context";
 import {useWorkerClient} from "../../general/client";
 import PerfectScrollbar from "react-perfect-scrollbar";
@@ -238,7 +239,7 @@ export const ListEditor = React.memo(({
 
     const worker = useContext(WorkerContext);
 
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { sendData } = useWorkerClient(worker);
 
     const [editing, setEditing] = useState({ actions: [] })
 
@@ -524,11 +525,11 @@ export const ListEditor = React.memo(({
     return true;
 }))
 
-export const GeneralStats = ({ stats, aspects, setDetailVisible }) => {
+const GeneralStatsComponent = ({ stats, aspects, setDetailVisible }) => {
 
     const worker = useContext(WorkerContext);
 
-    const { onMessage, sendData } = useWorkerClient(worker);
+    const { sendData } = useWorkerClient(worker);
 
     const {isMobile} = useAppContext();
 
@@ -542,32 +543,32 @@ export const GeneralStats = ({ stats, aspects, setDetailVisible }) => {
         if(!isIntensityHidden && currentTourId === 'aspects') {
             unlockNextById(1);
         }
-    }, [isIntensityHidden, currentTourId, stepIndex])
+    }, [isIntensityHidden, currentTourId, stepIndex, unlockNextById])
 
-    const setAspectLevel = (id, level) => {
+    const setAspectLevel = useCallback((id, level) => {
         sendData('set-action-aspect-level', { id, level });
-    }
+    }, [sendData]);
 
-    const toggleMaxed = (id, flag) => {
+    const toggleMaxed = useCallback((id, flag) => {
         sendData('toggle-action-aspect-maxed', { id, flag });
-    }
+    }, [sendData]);
 
     const hasEffect = (stat) => {
         if(!stat?.value) return false;
         return Math.abs(stat?.value - 1.0) > 1.e-7;
     }
 
-    const highLightAffectedActions = (id) => {
+    const highLightAffectedActions = useCallback((id) => {
         sendData('set-monitored', { scope: 'actions', type: 'learn_modifier', id });
-    }
+    }, [sendData]);
 
-    const highLightDiscountedActions = (id) => {
+    const highLightDiscountedActions = useCallback((id) => {
         sendData('set-monitored', { scope: 'actions', type: 'discount', id });
-    }
+    }, [sendData]);
 
     const setMonitoredAttribute = useCallback((id) => {
         sendData('set-monitored', { scope: 'actions', type: 'attribute', id });
-    }, []);
+    }, [sendData]);
 
     return (<PerfectScrollbar>
         {aspects.isUnlocked ? (<div className={'block aspects-block'}>
@@ -645,3 +646,35 @@ export const GeneralStats = ({ stats, aspects, setDetailVisible }) => {
         </div>) : null}
     </PerfectScrollbar>)
 }
+
+export const GeneralStats = React.memo(GeneralStatsComponent, (prevProps, nextProps) => {
+    if(prevProps.setDetailVisible !== nextProps.setDetailVisible) {
+        return false;
+    }
+
+    const prevStats = prevProps.stats ?? {};
+    const nextStats = nextProps.stats ?? {};
+
+    if(!isEqual(prevStats.learnMults, nextStats.learnMults)) {
+        return false;
+    }
+
+    if(!isEqual(prevStats.xpDiscounts, nextStats.xpDiscounts)) {
+        return false;
+    }
+
+    const prevAspects = prevProps.aspects ?? {};
+    const nextAspects = nextProps.aspects ?? {};
+
+    if((prevAspects.isUnlocked ?? false) !== (nextAspects.isUnlocked ?? false)) {
+        return false;
+    }
+
+    if(!isEqual(prevAspects.list, nextAspects.list)) {
+        return false;
+    }
+
+    return true;
+});
+
+GeneralStats.displayName = 'GeneralStats';

--- a/src/components/layout/main-menu.jsx
+++ b/src/components/layout/main-menu.jsx
@@ -15,6 +15,70 @@ const MENU_ITEMS = [
     { id: 'spellbook', label: 'Magic', unlockKey: 'spellbook', domId: 'main-menu-spellbook' },
 ];
 
+const isPlainObject = (value) => Object.prototype.toString.call(value) === '[object Object]';
+
+const cloneMenuValue = (value) => {
+    if (Array.isArray(value)) {
+        return value.map(cloneMenuValue);
+    }
+
+    if (isPlainObject(value)) {
+        const cloned = {};
+        for (const [key, nestedValue] of Object.entries(value)) {
+            cloned[key] = cloneMenuValue(nestedValue);
+        }
+        return cloned;
+    }
+
+    return value;
+};
+
+const areMenuValuesEqual = (prevValue, nextValue) => {
+    if (Object.is(prevValue, nextValue)) {
+        return true;
+    }
+
+    const prevIsArray = Array.isArray(prevValue);
+    const nextIsArray = Array.isArray(nextValue);
+    if (prevIsArray || nextIsArray) {
+        if (!prevIsArray || !nextIsArray || prevValue.length !== nextValue.length) {
+            return false;
+        }
+        for (let i = 0; i < prevValue.length; i += 1) {
+            if (!areMenuValuesEqual(prevValue[i], nextValue[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    const prevIsObject = isPlainObject(prevValue);
+    const nextIsObject = isPlainObject(nextValue);
+    if (prevIsObject || nextIsObject) {
+        if (!prevIsObject || !nextIsObject) {
+            return false;
+        }
+
+        const prevKeys = Object.keys(prevValue);
+        const nextKeys = Object.keys(nextValue);
+        if (prevKeys.length !== nextKeys.length) {
+            return false;
+        }
+
+        for (const key of prevKeys) {
+            if (!Object.prototype.hasOwnProperty.call(nextValue, key)) {
+                return false;
+            }
+            if (!areMenuValuesEqual(prevValue[key], nextValue[key])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    return false;
+};
+
 const areMenuMapsEqual = (prev = {}, next = {}) => {
     const prevKeys = Object.keys(prev);
     const nextKeys = Object.keys(next);
@@ -22,35 +86,16 @@ const areMenuMapsEqual = (prev = {}, next = {}) => {
 
     for (const key of prevKeys) {
         if (!Object.prototype.hasOwnProperty.call(next, key)) return false;
-        const prevValue = prev[key];
-        const nextValue = next[key];
-
-        const prevIsObject = typeof prevValue === 'object' && prevValue !== null;
-        const nextIsObject = typeof nextValue === 'object' && nextValue !== null;
-
-        if (prevIsObject && nextIsObject) {
-            const prevInnerKeys = Object.keys(prevValue);
-            const nextInnerKeys = Object.keys(nextValue);
-            if (prevInnerKeys.length !== nextInnerKeys.length) return false;
-            for (const innerKey of prevInnerKeys) {
-                if (!Object.prototype.hasOwnProperty.call(nextValue, innerKey)) return false;
-                if (!Object.is(prevValue[innerKey], nextValue[innerKey])) return false;
-            }
-            continue;
-        }
-
-        if (!Object.is(prevValue, nextValue)) return false;
+        if (!areMenuValuesEqual(prev[key], next[key])) return false;
     }
 
     return true;
 };
 
 const normalizeMenuMap = (map = {}) => {
-    const normalized = Object.create(null);
+    const normalized = {};
     for (const [key, value] of Object.entries(map || {})) {
-        normalized[key] = typeof value === 'object' && value !== null
-            ? { ...value }
-            : value;
+        normalized[key] = cloneMenuValue(value);
     }
     return normalized;
 };

--- a/src/components/layout/main-menu.jsx
+++ b/src/components/layout/main-menu.jsx
@@ -1,9 +1,61 @@
-import React, { useState, useEffect, useContext, useCallback } from "react";
+import React, { useState, useEffect, useContext, useCallback, useRef, useMemo } from "react";
 import WorkerContext from "../../context/worker-context";
 import { useWorkerClient } from "../../general/client";
 import { useAppContext } from "../../context/ui-context";
 import { NewNotificationWrap } from "../shared/new-notification-wrap.jsx";
-import {useTutorial} from "../../context/tutorial-context";
+
+const MENU_ITEMS = [
+    { id: 'actions', label: 'Actions', unlockKey: 'actions', domId: 'main-menu-actions' },
+    { id: 'shop', label: 'Shop', unlockKey: 'shop', domId: 'shop', lockedText: 'Locked (Reach 2 coins)' },
+    { id: 'inventory', label: 'Inventory', unlockKey: 'inventory', domId: 'main-menu-inventory' },
+    { id: 'property', label: 'Property', unlockKey: 'property', domId: 'main-menu-property' },
+    { id: 'world', label: 'World', unlockKey: 'world', domId: 'main-menu-world' },
+    { id: 'workshop', label: 'Workshop', unlockKey: 'workshop', domId: 'main-menu-workshop' },
+    { id: 'social', label: 'Social', unlockKey: 'social', domId: 'main-menu-social' },
+    { id: 'spellbook', label: 'Magic', unlockKey: 'spellbook', domId: 'main-menu-spellbook' },
+];
+
+const areMenuMapsEqual = (prev = {}, next = {}) => {
+    if (prev === next) return true;
+    const prevKeys = Object.keys(prev);
+    const nextKeys = Object.keys(next);
+    if (prevKeys.length !== nextKeys.length) return false;
+
+    for (const key of prevKeys) {
+        if (!Object.prototype.hasOwnProperty.call(next, key)) return false;
+        const prevValue = prev[key];
+        const nextValue = next[key];
+
+        const prevIsObject = typeof prevValue === 'object' && prevValue !== null;
+        const nextIsObject = typeof nextValue === 'object' && nextValue !== null;
+
+        if (prevIsObject && nextIsObject) {
+            const prevInnerKeys = Object.keys(prevValue);
+            const nextInnerKeys = Object.keys(nextValue);
+            if (prevInnerKeys.length !== nextInnerKeys.length) return false;
+            for (const innerKey of prevInnerKeys) {
+                if (!Object.prototype.hasOwnProperty.call(nextValue, innerKey)) return false;
+                if (!Object.is(prevValue[innerKey], nextValue[innerKey])) return false;
+            }
+            continue;
+        }
+
+        if (!Object.is(prevValue, nextValue)) return false;
+    }
+
+    return true;
+};
+
+const buildHotkeyLookup = (hotkeys = {}) => {
+    const lookup = Object.create(null);
+    for (const hotkey of Object.values(hotkeys)) {
+        const combination = hotkey?.combination?.toUpperCase();
+        if (combination) {
+            lookup[combination] = hotkey;
+        }
+    }
+    return lookup;
+};
 
 export const MainMenu = () => {
     const worker = useContext(WorkerContext);
@@ -11,8 +63,9 @@ export const MainMenu = () => {
     const { openedTab, setOpenedTab, togglePopup } = useAppContext();
     const [unlocks, setUnlocksData] = useState({});
     const [newUnlocks, setNewUnlocks] = useState({});
-    const [hotkeys, setHotkeys] = useState({});
-    const { stepIndex, unlockNextById, jumpOver, currentTourId } = useTutorial();
+    const unlocksRef = useRef(unlocks);
+    const newUnlocksRef = useRef(newUnlocks);
+    const hotkeyMapRef = useRef(Object.create(null));
 
     useEffect(() => {
         sendData('query-unlocks', { prefix: 'main-menu' });
@@ -27,10 +80,28 @@ export const MainMenu = () => {
         return () => {
             clearInterval(interval);
         }
-    }, []);
+    }, [sendData]);
 
-    const triggerHotkey = (combination) => {
-        const hotkey = Object.values(hotkeys || {}).find(h => h.combination === combination);
+    const openTab = useCallback((id) => {
+        setOpenedTab(id);
+    }, [setOpenedTab]);
+
+    const updateUnlocks = useCallback((nextUnlocks = {}) => {
+        if (!areMenuMapsEqual(unlocksRef.current, nextUnlocks)) {
+            unlocksRef.current = nextUnlocks;
+            setUnlocksData(nextUnlocks);
+        }
+    }, [setUnlocksData]);
+
+    const updateNewUnlocks = useCallback((nextNewUnlocks = {}) => {
+        if (!areMenuMapsEqual(newUnlocksRef.current, nextNewUnlocks)) {
+            newUnlocksRef.current = nextNewUnlocks;
+            setNewUnlocks(nextNewUnlocks);
+        }
+    }, [setNewUnlocks]);
+
+    const triggerHotkey = useCallback((combination) => {
+        const hotkey = hotkeyMapRef.current[combination];
 
         if(!hotkey) return;
 
@@ -39,11 +110,7 @@ export const MainMenu = () => {
         } else if(hotkey.action === 'openQuickAccess') {
             togglePopup('quick-access');
         }
-    }
-
-    const openTab = useCallback((id) => {
-        setOpenedTab(id);
-    }, [setOpenedTab]);
+    }, [openTab, togglePopup]);
 
     useEffect(() => {
         const isEditableTarget = (el) => {
@@ -78,18 +145,18 @@ export const MainMenu = () => {
             if (event.shiftKey) keys.push("Shift");
             if (event.altKey) keys.push("Alt");
             keys.push(event.key.toUpperCase());
-            const combination = keys.join("+");
+            const combination = keys.join("+").toUpperCase();
 
             triggerHotkey(combination); // Call triggerHotkey when a combination is pressed
         };
 
         window.addEventListener("keydown", handleKeyDown, { capture: true });
         return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
-    }, [hotkeys]);
+    }, [triggerHotkey]);
 
     useEffect(() => {
         const handleAllHotkeys = (payload) => {
-            setHotkeys(payload);
+            hotkeyMapRef.current = buildHotkeyLookup(payload);
         };
 
         const handleHotkeyTriggered = (hotkey) => {
@@ -102,8 +169,8 @@ export const MainMenu = () => {
 
         onMessage('all-hotkeys-all', handleAllHotkeys);
         onMessage('hotkey-triggered', handleHotkeyTriggered);
-        onMessage('unlocks-main-menu', setUnlocksData);
-        onMessage('new-unlocks-notifications-main-menu', setNewUnlocks);
+        onMessage('unlocks-main-menu', updateUnlocks);
+        onMessage('new-unlocks-notifications-main-menu', updateNewUnlocks);
 
         return () => {
             removeMessage('all-hotkeys-all');
@@ -111,73 +178,48 @@ export const MainMenu = () => {
             removeMessage('unlocks-main-menu');
             removeMessage('new-unlocks-notifications-main-menu');
         };
-    }, [onMessage, removeMessage, openTab, togglePopup, setUnlocksData, setNewUnlocks]);
+    }, [onMessage, removeMessage, openTab, togglePopup, updateUnlocks, updateNewUnlocks]);
+
+    const menuItems = useMemo(() => MENU_ITEMS.map((item) => {
+        const isUnlocked = Boolean(unlocks[item.unlockKey]);
+        const hasNotification = Boolean(newUnlocks[item.unlockKey]?.hasNew);
+
+        return {
+            ...item,
+            isUnlocked,
+            hasNotification,
+        };
+    }), [unlocks, newUnlocks]);
 
     return (
         <div className={'left-most'}>
             <ul className={'menu bigger'}>
-                {unlocks.actions && (
-                    <li id={'main-menu-actions'} className={openedTab === 'actions' ? 'active' : ''} onClick={() => {
-                        setOpenedTab('actions')
-                    }}>
-                        <NewNotificationWrap isNew={newUnlocks.actions?.hasNew}>
-                            <span>Actions</span>
-                        </NewNotificationWrap>
-                    </li>
-                )}
-                {unlocks.shop ? (
-                    <li id={'shop'} className={openedTab === 'shop' ? 'active' : ''} onClick={() => setOpenedTab('shop')}>
-                        <NewNotificationWrap isNew={newUnlocks.shop?.hasNew}>
-                            <span>Shop</span>
-                        </NewNotificationWrap>
-                    </li>
-                ) : (
-                    <li id={'shop'} className={'locked'}>
-                        <span>Locked (Reach 2 coins)</span>
-                    </li>
-                )}
-                {unlocks.inventory && (
-                    <li id={'main-menu-inventory'} className={openedTab === 'inventory' ? 'active' : ''} onClick={() => setOpenedTab('inventory')}>
-                        <NewNotificationWrap isNew={newUnlocks.inventory?.hasNew}>
-                            <span>Inventory</span>
-                        </NewNotificationWrap>
-                    </li>
-                )}
-                {unlocks.property && (
-                    <li id={'main-menu-property'} className={openedTab === 'property' ? 'active' : ''} onClick={() => setOpenedTab('property')}>
-                        <NewNotificationWrap isNew={newUnlocks.property?.hasNew}>
-                            <span>Property</span>
-                        </NewNotificationWrap>
-                    </li>
-                )}
-                {unlocks.world && (
-                    <li id={'main-menu-world'} className={openedTab === 'world' ? 'active' : ''} onClick={() => setOpenedTab('world')}>
-                        <NewNotificationWrap isNew={newUnlocks.world?.hasNew}>
-                            <span>World</span>
-                        </NewNotificationWrap>
-                    </li>
-                )}
-                {unlocks.workshop && (
-                    <li id={'main-menu-workshop'} className={openedTab === 'workshop' ? 'active' : ''} onClick={() => setOpenedTab('workshop')}>
-                        <NewNotificationWrap isNew={newUnlocks.workshop?.hasNew}>
-                            <span>Workshop</span>
-                        </NewNotificationWrap>
-                    </li>
-                )}
-                {unlocks.social && (
-                    <li id={'main-menu-social'} className={openedTab === 'social' ? 'active' : ''} onClick={() => setOpenedTab('social')}>
-                        <NewNotificationWrap isNew={newUnlocks.social?.hasNew}>
-                            <span>Social</span>
-                        </NewNotificationWrap>
-                    </li>
-                )}
-                {unlocks.spellbook && (
-                    <li id={'main-menu-spellbook'} className={openedTab === 'spellbook' ? 'active' : ''} onClick={() => setOpenedTab('spellbook')}>
-                        <NewNotificationWrap isNew={newUnlocks.spellbook?.hasNew}>
-                            <span>Magic</span>
-                        </NewNotificationWrap>
-                    </li>
-                )}
+                {menuItems.map(({ id, domId, label, isUnlocked, hasNotification, lockedText }) => {
+                    if (!isUnlocked && !lockedText) {
+                        return null;
+                    }
+
+                    if (!isUnlocked) {
+                        return (
+                            <li key={id} id={domId} className={'locked'}>
+                                <span>{lockedText}</span>
+                            </li>
+                        );
+                    }
+
+                    return (
+                        <li
+                            key={id}
+                            id={domId}
+                            className={openedTab === id ? 'active' : ''}
+                            onClick={() => openTab(id)}
+                        >
+                            <NewNotificationWrap isNew={hasNotification}>
+                                <span>{label}</span>
+                            </NewNotificationWrap>
+                        </li>
+                    );
+                })}
             </ul>
         </div>
     );

--- a/src/components/layout/main-menu.jsx
+++ b/src/components/layout/main-menu.jsx
@@ -16,7 +16,6 @@ const MENU_ITEMS = [
 ];
 
 const areMenuMapsEqual = (prev = {}, next = {}) => {
-    if (prev === next) return true;
     const prevKeys = Object.keys(prev);
     const nextKeys = Object.keys(next);
     if (prevKeys.length !== nextKeys.length) return false;
@@ -44,6 +43,16 @@ const areMenuMapsEqual = (prev = {}, next = {}) => {
     }
 
     return true;
+};
+
+const normalizeMenuMap = (map = {}) => {
+    const normalized = Object.create(null);
+    for (const [key, value] of Object.entries(map || {})) {
+        normalized[key] = typeof value === 'object' && value !== null
+            ? { ...value }
+            : value;
+    }
+    return normalized;
 };
 
 const buildHotkeyLookup = (hotkeys = {}) => {
@@ -87,16 +96,18 @@ export const MainMenu = () => {
     }, [setOpenedTab]);
 
     const updateUnlocks = useCallback((nextUnlocks = {}) => {
-        if (!areMenuMapsEqual(unlocksRef.current, nextUnlocks)) {
-            unlocksRef.current = nextUnlocks;
-            setUnlocksData(nextUnlocks);
+        const normalizedUnlocks = normalizeMenuMap(nextUnlocks);
+        if (!areMenuMapsEqual(unlocksRef.current, normalizedUnlocks)) {
+            unlocksRef.current = normalizedUnlocks;
+            setUnlocksData(normalizedUnlocks);
         }
     }, [setUnlocksData]);
 
     const updateNewUnlocks = useCallback((nextNewUnlocks = {}) => {
-        if (!areMenuMapsEqual(newUnlocksRef.current, nextNewUnlocks)) {
-            newUnlocksRef.current = nextNewUnlocks;
-            setNewUnlocks(nextNewUnlocks);
+        const normalizedNewUnlocks = normalizeMenuMap(nextNewUnlocks);
+        if (!areMenuMapsEqual(newUnlocksRef.current, normalizedNewUnlocks)) {
+            newUnlocksRef.current = normalizedNewUnlocks;
+            setNewUnlocks(normalizedNewUnlocks);
         }
     }, [setNewUnlocks]);
 

--- a/src/components/layout/personage-circle.jsx
+++ b/src/components/layout/personage-circle.jsx
@@ -1,18 +1,52 @@
-import React, { useState, useEffect, useRef, useContext } from "react";
+import React, { useState, useEffect, useRef, useContext, useMemo, useCallback } from "react";
 import WorkerContext from "../../context/worker-context";
 import { useWorkerClient } from "../../general/client";
 import { useAppContext } from "../../context/ui-context";
 import { TippyWrapper } from "../shared/tippy-wrapper.jsx";
-import { ProgressBar } from "./progress-bar.jsx";
 import {formatInt, formatValue, secondsToString} from "../../general/utils/strings";
+
+const PREVIEW_ACTIONS = 5;
+
+const areMageSnapshotsEqual = (prev = {}, next = {}) => {
+    if (prev === next) return true;
+    const keysToCompare = ['mageLevel', 'mageXP', 'mageMaxXP', 'xpTotalIncome', 'eta', 'skillPoints'];
+    for (const key of keysToCompare) {
+        if (!Object.is(prev?.[key], next?.[key])) {
+            return false;
+        }
+    }
+
+    return areBalancePreviewsEqual(prev?.xpBalance, next?.xpBalance);
+};
+
+const areBalancePreviewsEqual = (prevBalance, nextBalance) => {
+    const prevActions = prevBalance?.actions || [];
+    const nextActions = nextBalance?.actions || [];
+
+    if (prevActions.length !== nextActions.length) return false;
+
+    const previewLength = Math.min(PREVIEW_ACTIONS, nextActions.length, prevActions.length);
+    for (let index = 0; index < previewLength; index += 1) {
+        const prevAction = prevActions[index];
+        const nextAction = nextActions[index];
+        if (!prevAction && !nextAction) continue;
+        if (!prevAction || !nextAction) return false;
+        if (prevAction.name !== nextAction.name) return false;
+        if (!Object.is(prevAction.dxp, nextAction.dxp)) return false;
+    }
+
+    return true;
+};
 
 export const PersonageCircle = () => {
     const worker = useContext(WorkerContext);
     const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { togglePopup } = useAppContext();
-    const [mageData, setMageData] = useState({});
-    const [settings, setSettings] = useState({});
+    const [mageData, setMageData] = useState(null);
+    const [notation, setNotation] = useState(null);
     const elementRef = useRef(null);
+    const mageDataRef = useRef(null);
+    const notationRef = useRef(null);
 
     useEffect(() => {
         sendData('query-mage-data', { prefix: 'xpbar' });
@@ -24,17 +58,27 @@ export const PersonageCircle = () => {
         return () => {
             clearInterval(interval);
         }
-    }, []);
+    }, [sendData]);
 
     useEffect(() => {
-        window.notation = settings.notation;
-    }, [settings?.notation]);
+        if (notation !== undefined && notation !== null) {
+            window.notation = notation;
+        }
+    }, [notation]);
 
     useEffect(() => {
         const handleMageData = (data) => {
             const {settings: settingsData, ...mage} = data;
-            setMageData(mage);
-            setSettings(settingsData);
+
+            if (settingsData?.notation !== notationRef.current) {
+                notationRef.current = settingsData?.notation;
+                setNotation(settingsData?.notation ?? null);
+            }
+
+            if (!areMageSnapshotsEqual(mageDataRef.current, mage)) {
+                mageDataRef.current = mage;
+                setMageData(mage);
+            }
         };
 
         onMessage('mage-data-xpbar', handleMageData);
@@ -44,28 +88,63 @@ export const PersonageCircle = () => {
         };
     }, [onMessage, removeMessage]);
 
-    return mageData ? (
-        <div className={'mage-wrap flex-container'} ref={elementRef}>
-            <TippyWrapper placement={"top"} content={<div className={'hint-popup'}>
+    const handleSkillsClick = useCallback(() => {
+        togglePopup('skills');
+    }, [togglePopup]);
+
+    const xpCircleStyle = useMemo(() => {
+        if (!mageData) {
+            return { '--angle': 0 };
+        }
+        const xp = mageData.mageXP ?? 0;
+        const max = mageData.mageMaxXP ?? 0;
+        const angle = (xp / (max + 1.e-8)) * 360;
+        return { '--angle': `${angle}` };
+    }, [mageData?.mageXP, mageData?.mageMaxXP]);
+
+    const balancePreview = useMemo(() => {
+        const actions = mageData?.xpBalance?.actions || [];
+        const preview = actions.slice(0, PREVIEW_ACTIONS);
+        const remaining = Math.max(actions.length - PREVIEW_ACTIONS, 0);
+        return { preview, remaining };
+    }, [mageData?.xpBalance]);
+
+    const tooltipContent = useMemo(() => {
+        if (!mageData) return null;
+
+        return (
+            <div className={'hint-popup'}>
                 <p>Level: {formatInt(mageData.mageLevel)}</p>
                 <p>XP: {formatInt(mageData.mageXP)} / {formatInt(mageData.mageMaxXP)}</p>
                 <p>XP/sec: {formatValue(mageData.xpTotalIncome)}</p>
                 <p>Next level in: {secondsToString(mageData.eta)}</p>
-                {mageData?.xpBalance ? (<div className={'balances block'}>
-                    {mageData.xpBalance.actions?.splice(0, 5).map((balance, index) => (<p key={index} className={'small-hint'}>Running action - {balance.name}: {formatValue(balance.dxp)}</p>))}
-                    {mageData.xpBalance.actions?.length ? (<p className={'small-hint'}>And {formatInt(mageData.xpBalance.actions?.length)} more</p>) : null}
-                </div> ) : null}
-            </div>}>
+                {mageData?.xpBalance ? (
+                    <div className={'balances block'}>
+                        {balancePreview.preview.map((balance, index) => (
+                            <p key={`${balance?.name}-${index}`} className={'small-hint'}>
+                                Running action - {balance?.name}: {formatValue(balance?.dxp)}
+                            </p>
+                        ))}
+                        {balancePreview.remaining ? (
+                            <p className={'small-hint'}>And {formatInt(balancePreview.remaining)} more</p>
+                        ) : null}
+                    </div>
+                ) : null}
+            </div>
+        );
+    }, [mageData, balancePreview]);
+
+    return mageData ? (
+        <div className={'mage-wrap flex-container'} ref={elementRef}>
+            <TippyWrapper placement={"top"} content={tooltipContent}>
                 <div className={'outer-xp-circle'}>
                     <div
                         className={'inner-xp-circle'}
-                        style={{
-                            '--angle': `${(mageData.mageXP/(mageData.mageMaxXP + 1.e-8)) * 360}`,
-                        }}
+                        style={xpCircleStyle}
                     >
                         <div className={'holder-circle'}>
                             <div className={'level'} id={'level'}>
-                                <span className={`skills-button ${mageData.skillPoints > 0 ? 'highlight' : ''}`} onClick={() => togglePopup('skills')}>
+                                <span className={`skills-button ${mageData.skillPoints > 0 ? 'highlight' : ''}`} onClick={handleSkillsClick}>
                                     <img src={'icons/ui/sp.png'} />
                                     <span>{mageData.skillPoints}</span>
                                 </span>

--- a/src/components/layout/sidebar.jsx
+++ b/src/components/layout/sidebar.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, useContext, useCallback} from "react";
+import React, {useEffect, useState, useContext, useCallback, useRef} from "react";
 import isEqual from "lodash/isEqual";
 import WorkerContext from "../../context/worker-context";
 import {useWorkerClient} from "../../general/client";
@@ -73,6 +73,12 @@ export const ResourcesBar = () => {
 
     const resourceData = useSidebarData(state => state.resources);
 
+    const sendDataRef = useRef(sendData);
+
+    useEffect(() => {
+        sendDataRef.current = sendData;
+    }, [sendData]);
+
     useEffect(() => {
         if (!worker) {
             return undefined;
@@ -95,8 +101,11 @@ export const ResourcesBar = () => {
     }, [worker, onMessage, sendData, removeMessage]);
 
     const setMonitoredAttribute = useCallback((id) => {
-        sendData('set-monitored', { scope: 'actions', type: 'resource', id });
-    }, [sendData]);
+        const fn = sendDataRef.current;
+        if(!fn) { return; }
+
+        fn('set-monitored', { scope: 'actions', type: 'resource', id });
+    }, []);
 
     const handleMouseEnter = useCallback((resource) => {
         setMonitoredAttribute(resource?.id ?? null);
@@ -107,8 +116,11 @@ export const ResourcesBar = () => {
     }, [setMonitoredAttribute]);
 
     const consumeResource = useCallback((id, amount = 1) => {
-        sendData('consume-inventory', { id, amount, sendDetails: true });
-    }, [sendData]);
+        const fn = sendDataRef.current;
+        if(!fn) { return; }
+
+        fn('consume-inventory', { id, amount, sendDetails: true });
+    }, []);
 
     const handleResourceContextMenu = useCallback((e, resource) => {
         e.preventDefault();

--- a/src/components/layout/sidebar.jsx
+++ b/src/components/layout/sidebar.jsx
@@ -1,4 +1,5 @@
 import React, {useEffect, useState, useContext, useCallback} from "react";
+import isEqual from "lodash/isEqual";
 import WorkerContext from "../../context/worker-context";
 import {useWorkerClient} from "../../general/client";
 import {formatInt, formatValue, secondsToString} from "../../general/utils/strings";
@@ -134,7 +135,7 @@ export const ResourcesBar = () => {
     </div> )
 }
 
-export const ResourceRow = React.memo(({ resource, onMouseEnter, onMouseLeave, onContextMenu, showCapProgress = true, onToggleHidden }) => {
+const ResourceRowComponent = ({ resource, onMouseEnter, onMouseLeave, onContextMenu, showCapProgress = true, onToggleHidden }) => {
 
     const aff = resource.monitor;
 
@@ -265,9 +266,34 @@ export const ResourceRow = React.memo(({ resource, onMouseEnter, onMouseLeave, o
             <div className={'next-unlock-bar'} style={{ width: `${resource.capProgress*100}%`}}></div>
         </div>) : null}
     </div> )
+};
+
+export const ResourceRow = React.memo(ResourceRowComponent, (prevProps, nextProps) => {
+    if(prevProps.showCapProgress !== nextProps.showCapProgress) {
+        return false;
+    }
+
+    if(prevProps.onToggleHidden !== nextProps.onToggleHidden) {
+        return false;
+    }
+
+    if(prevProps.onMouseEnter !== nextProps.onMouseEnter) {
+        return false;
+    }
+
+    if(prevProps.onMouseLeave !== nextProps.onMouseLeave) {
+        return false;
+    }
+
+    if(prevProps.onContextMenu !== nextProps.onContextMenu) {
+        return false;
+    }
+
+    return isEqual(prevProps.resource, nextProps.resource);
 });
 
 ResourceRow.displayName = 'ResourceRow';
+
 
 export const AttributesBar = () => {
     const worker = useContext(WorkerContext);

--- a/src/components/mage/statistics.jsx
+++ b/src/components/mage/statistics.jsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useState, useMemo, useCallback} from "react";
+import React, {useContext, useEffect, useState, useMemo, useCallback, useRef} from "react";
 import {formatInt, formatValue, secondsToString} from "../../general/utils/strings";
 import PerfectScrollbar from "react-perfect-scrollbar";
 import WorkerContext from "../../context/worker-context";
@@ -87,6 +87,7 @@ export const Statistics = () => {
 
     const worker = useContext(WorkerContext);
     const { onMessage, sendData } = useWorkerClient(worker);
+    const sendDataRef = useRef(sendData);
 
     const [stats, setStats] = useState({ multipliers: [], resources: [] });
     const [preferences, setPreferences] = useState({ multipliersShowHidden: false, resourcesShowHidden: false });
@@ -172,21 +173,31 @@ export const Statistics = () => {
         });
     }, [stats.resources, resourcesFilter, preferences.resourcesShowHidden]);
 
+    useEffect(() => {
+        sendDataRef.current = sendData;
+    }, [sendData]);
+
     const handleToggleMultiplierHidden = useCallback((multiplier) => {
         if(!multiplier?.id) {
             return;
         }
 
-        sendData('toggle-statistics-hidden', { scope: 'multipliers', id: multiplier.id });
-    }, [sendData]);
+        const fn = sendDataRef.current;
+        if(!fn) { return; }
+
+        fn('toggle-statistics-hidden', { scope: 'multipliers', id: multiplier.id });
+    }, []);
 
     const handleToggleResourceHidden = useCallback((resource) => {
         if(!resource?.id) {
             return;
         }
 
-        sendData('toggle-statistics-hidden', { scope: 'resources', id: resource.id });
-    }, [sendData]);
+        const fn = sendDataRef.current;
+        if(!fn) { return; }
+
+        fn('toggle-statistics-hidden', { scope: 'resources', id: resource.id });
+    }, []);
 
     const handleMultipliersShowHiddenChange = useCallback(() => {
         const next = !preferences.multipliersShowHidden;

--- a/src/components/shared/favorite-button.jsx
+++ b/src/components/shared/favorite-button.jsx
@@ -1,9 +1,9 @@
-import React, { useContext, useCallback } from "react";
+import React, { useContext, useCallback, useMemo } from "react";
 import WorkerContext from "../../context/worker-context";
 import { useWorkerClient } from "../../general/client";
 import { CustomButton } from "./buttons/custom-button.jsx";
 
-export const FavoriteButton = ({ type, id, isFavorite = false, className = "" }) => {
+const FavoriteButtonComponent = ({ type, id, isFavorite = false, className = "" }) => {
     const worker = useContext(WorkerContext);
     const { sendData } = useWorkerClient(worker);
 
@@ -11,15 +11,28 @@ export const FavoriteButton = ({ type, id, isFavorite = false, className = "" })
         e.preventDefault();
         e.stopPropagation();
         sendData('toggle-favorite', { type, id });
-    }, [type, id]);
+    }, [type, id, sendData]);
+
+    const favoriteClassName = useMemo(() => (
+        `favorite-btn ${isFavorite ? 'favorited' : ''} ${className}`.trim()
+    ), [className, isFavorite]);
 
     return (
         <CustomButton
             iconId="favorite"
-            className={`favorite-btn ${isFavorite ? 'favorited' : ''} ${className}`}
+            className={favoriteClassName}
             onClick={toggleFavorite}
         >
             {isFavorite ? 'Remove from Favorites' : 'Add to Favorites'}
         </CustomButton>
     );
-}; 
+};
+
+const areFavoriteButtonPropsEqual = (prevProps, nextProps) => (
+    prevProps.type === nextProps.type
+    && prevProps.id === nextProps.id
+    && prevProps.isFavorite === nextProps.isFavorite
+    && prevProps.className === nextProps.className
+);
+
+export const FavoriteButton = React.memo(FavoriteButtonComponent, areFavoriteButtonPropsEqual);

--- a/src/components/shared/new-notification-wrap.jsx
+++ b/src/components/shared/new-notification-wrap.jsx
@@ -1,7 +1,6 @@
-import React, {useCallback, useContext, useEffect, useMemo, useState} from "react";
+import React, {useCallback, useContext, useEffect, useRef, useState} from "react";
 import WorkerContext from "../../context/worker-context";
 import {useWorkerClient} from "../../general/client";
-import { debounce } from 'lodash';
 
 const NewNotificationWrapComponent = ({ isNew, id, className = '', children }) => {
     const worker = useContext(WorkerContext);
@@ -13,20 +12,43 @@ const NewNotificationWrapComponent = ({ isNew, id, className = '', children }) =
         setIsNewLocal(!!isNew);
     }, [isNew]);
 
-    const setViewed = useMemo(() => debounce(() => {
-        if (id) {
+    const viewedTimeoutRef = useRef(null);
+
+    const clearViewedTimeout = useCallback(() => {
+        if (viewedTimeoutRef.current) {
+            clearTimeout(viewedTimeoutRef.current);
+            viewedTimeoutRef.current = null;
+        }
+    }, []);
+
+    useEffect(() => clearViewedTimeout, [clearViewedTimeout]);
+
+    useEffect(() => {
+        clearViewedTimeout();
+    }, [clearViewedTimeout, id]);
+
+    useEffect(() => {
+        if (!isNewLocal) {
+            clearViewedTimeout();
+        }
+    }, [clearViewedTimeout, isNewLocal]);
+
+    const scheduleViewed = useCallback(() => {
+        if (!id || !isNewLocal) {
+            return;
+        }
+
+        clearViewedTimeout();
+        viewedTimeoutRef.current = window.setTimeout(() => {
             sendData('set-new-notification-viewed-by-id', { id });
             setIsNewLocal(false);
-        }
-    }, 1000, { leading: false, trailing: true }), [id, sendData]);
-
-    useEffect(() => () => {
-        setViewed.cancel();
-    }, [setViewed]);
+            viewedTimeoutRef.current = null;
+        }, 1000);
+    }, [clearViewedTimeout, id, isNewLocal, sendData]);
 
     const handleMouseOver = useCallback(() => {
-        setViewed();
-    }, [setViewed]);
+        scheduleViewed();
+    }, [scheduleViewed]);
 
     return (
         <div

--- a/src/components/shared/tippy-wrapper.jsx
+++ b/src/components/shared/tippy-wrapper.jsx
@@ -1,63 +1,99 @@
-import React, { cloneElement, isValidElement, useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, {
+    cloneElement,
+    isValidElement,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import ReactDOM from "react-dom";
 import { useTippyContext } from "../../context/tippy-context.jsx";
 
 const NOOP = () => {};
 
-export const TippyWrapper = ({
-                                 content,
-                                 children,
-                                 placement = 'right',
-                                  onShow = NOOP,
-                                  onHide = NOOP,
-                                 lazy = false,
-                             }) => {
+const placementsPriority = {
+    top: ['top', 'bottom'],
+    bottom: ['bottom', 'top'],
+    left: ['left', 'right'],
+    right: ['right', 'left'],
+};
+
+const isPrimitive = value => value === null || (typeof value !== 'object' && typeof value !== 'function');
+
+function areReactNodesEqual(prevNode, nextNode) {
+    if (prevNode === nextNode) {
+        return true;
+    }
+
+    if (Array.isArray(prevNode) || Array.isArray(nextNode)) {
+        return areNodeArraysEqual(prevNode, nextNode);
+    }
+
+    if (isPrimitive(prevNode) || isPrimitive(nextNode)) {
+        return Object.is(prevNode, nextNode);
+    }
+
+    if (!isValidElement(prevNode) || !isValidElement(nextNode)) {
+        return false;
+    }
+
+    if (prevNode.type !== nextNode.type || prevNode.key !== nextNode.key) {
+        return false;
+    }
+
+    const prevProps = prevNode.props || {};
+    const nextProps = nextNode.props || {};
+
+    const prevPropKeys = Object.keys(prevProps).filter(key => key !== 'children');
+    const nextPropKeys = Object.keys(nextProps).filter(key => key !== 'children');
+
+    if (prevPropKeys.length !== nextPropKeys.length) {
+        return false;
+    }
+
+    for (const key of prevPropKeys) {
+        if (!Object.prototype.hasOwnProperty.call(nextProps, key)) {
+            return false;
+        }
+
+        if (!Object.is(prevProps[key], nextProps[key])) {
+            return false;
+        }
+    }
+
+    return areReactNodesEqual(prevProps.children, nextProps.children);
+}
+
+function areNodeArraysEqual(a, b) {
+    if (a === b) return true;
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+        if (!areReactNodesEqual(a[i], b[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+const TippyWrapperComponent = ({
+    content,
+    children,
+    placement = 'right',
+    onShow = NOOP,
+    onHide = NOOP,
+    lazy = false,
+}) => {
     const [visible, setVisible] = useState(false);
     const ref = useRef();
     const popoverRef = useRef();
+    const visibleRef = useRef(false);
     const { portalContainer } = useTippyContext();
+    const childIsValid = isValidElement(children);
 
-    const placementsPriority = {
-        top: ['top', 'bottom'],
-        bottom: ['bottom', 'top'],
-        left: ['left', 'right'],
-        right: ['right', 'left'],
-    };
-
-    useEffect(() => {
-        if (visible) {
-            onShow();
-        } else {
-            onHide();
-        }
-        // Depend only on visibility to avoid retriggers from new function identities
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [visible]);
-
-    // Use global portal container instead of creating new ones
-    useEffect(() => {
-        // Додаємо ResizeObserver для автоматичного оновлення позиції
-        let resizeObserver = null;
-        if (window.ResizeObserver) {
-            resizeObserver = new ResizeObserver(() => {
-                if (visible && popoverRef.current) {
-                    // Невелика затримка для стабілізації
-                    setTimeout(() => positionPopover(), 50);
-                }
-            });
-            resizeObserver.observe(document.body);
-        }
-        
-        // Cleanup on unmount
-        return () => {
-            setVisible(false); // Hide popover before unmounting
-            if (resizeObserver) {
-                resizeObserver.disconnect();
-            }
-        };
-    }, []);
-
-    const positionPopover = () => {
+    const positionPopover = useCallback(() => {
         if (!popoverRef.current || !ref.current) return;
 
         const targetRect = ref.current.getBoundingClientRect();
@@ -120,7 +156,39 @@ export const TippyWrapper = ({
         popover.style.top = `${clampedTop}px`;
         popover.style.left = `${clampedLeft}px`;
         popover.setAttribute('data-placement', finalPlacement);
-    };
+    }, [placement]);
+
+    useEffect(() => {
+        visibleRef.current = visible;
+        if (visible) {
+            onShow();
+        } else {
+            onHide();
+        }
+    }, [visible, onShow, onHide]);
+
+    // Use global portal container instead of creating new ones
+    useEffect(() => {
+        // Додаємо ResizeObserver для автоматичного оновлення позиції
+        let resizeObserver = null;
+        if (window.ResizeObserver) {
+            resizeObserver = new ResizeObserver(() => {
+                if (visibleRef.current && popoverRef.current) {
+                    // Невелика затримка для стабілізації
+                    setTimeout(() => positionPopover(), 50);
+                }
+            });
+            resizeObserver.observe(document.body);
+        }
+
+        // Cleanup on unmount
+        return () => {
+            setVisible(false); // Hide popover before unmounting
+            if (resizeObserver) {
+                resizeObserver.disconnect();
+            }
+        };
+    }, [positionPopover]);
 
     useLayoutEffect(() => {
         if (!visible) return;
@@ -131,7 +199,7 @@ export const TippyWrapper = ({
             }
         });
         return () => cancelAnimationFrame(raf);
-    }, [visible, placement]);
+    }, [visible, positionPopover]);
 
     useEffect(() => {
         if (!visible && popoverRef.current) {
@@ -141,22 +209,22 @@ export const TippyWrapper = ({
 
     // useEffect для відстеження змін popoverRef.current
 
-    const handleMouseEnter = () => {
+    const handleMouseEnter = useCallback(() => {
         if (!ref.current) return;
-        
+
         // Перевіряємо чи елемент все ще видимий
         const rect = ref.current.getBoundingClientRect();
         if (rect.width === 0 || rect.height === 0) return;
 
         // Спочатку монтуємо прихований елемент, наступним кадром позиціюємо і показуємо
         setVisible(prev => (prev ? prev : true));
-    };
+    }, []);
 
-    const handleMouseLeave = () => {
+    const handleMouseLeave = useCallback(() => {
         setVisible(false);
-    };
+    }, []);
 
-    const handleMouseMove = () => {
+    const handleMouseMove = useCallback(() => {
         if (visible && ref.current && popoverRef.current) {
             // Оновлюємо позицію при руху миші (якщо потрібно)
             const rect = ref.current.getBoundingClientRect();
@@ -164,21 +232,22 @@ export const TippyWrapper = ({
                 positionPopover();
             }
         }
-    };
+    }, [positionPopover, visible]);
 
-    if (!isValidElement(children)) {
-        console.warn('TippyWrapper: children must be a single valid React element');
-        return children;
-    }
+    const cloned = useMemo(() => {
+        if (!childIsValid) {
+            return children;
+        }
 
-    const cloned = cloneElement(children, {
-        ref,
-        onMouseEnter: handleMouseEnter,
-        onMouseLeave: handleMouseLeave,
-        onMouseMove: handleMouseMove,
-    });
+        return cloneElement(children, {
+            ref,
+            onMouseEnter: handleMouseEnter,
+            onMouseLeave: handleMouseLeave,
+            onMouseMove: handleMouseMove,
+        });
+    }, [childIsValid, children, handleMouseEnter, handleMouseLeave, handleMouseMove]);
 
-    const popoverElement = visible ? (
+    const popoverElement = useMemo(() => (visible && childIsValid ? (
         <div
             ref={popoverRef}
             className="custom-popover"
@@ -186,7 +255,12 @@ export const TippyWrapper = ({
         >
             {lazy ? content : content}
         </div>
-    ) : null;
+    ) : null), [childIsValid, content, lazy, visible]);
+
+    if (!childIsValid) {
+        console.warn('TippyWrapper: children must be a single valid React element');
+        return children;
+    }
 
     // Додаємо логи перед return
     // console.log('RENDER - Portal container:', portalContainer);
@@ -202,3 +276,30 @@ export const TippyWrapper = ({
         </>
     );
 };
+
+export const TippyWrapper = React.memo(
+    TippyWrapperComponent,
+    (prevProps, nextProps) => {
+        if (prevProps.lazy !== nextProps.lazy) {
+            return false;
+        }
+
+        if (prevProps.placement !== nextProps.placement) {
+            return false;
+        }
+
+        if (prevProps.onShow !== nextProps.onShow || prevProps.onHide !== nextProps.onHide) {
+            return false;
+        }
+
+        if (!areReactNodesEqual(prevProps.content, nextProps.content)) {
+            return false;
+        }
+
+        if (!areReactNodesEqual(prevProps.children, nextProps.children)) {
+            return false;
+        }
+
+        return true;
+    },
+);


### PR DESCRIPTION
## Summary
- memoize the actions GeneralStats blade to avoid rerenders when parent state changes
- stabilize worker callbacks used by the blade to keep dependencies consistent
- wrap the sidebar ResourceRow in a comparator that ignores unchanged worker payloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f0941f908320a490e8884cdebfa9)