### PR TITLE
Optimize inventory rendering

### DIFF
--- a/src/components/inventory/inventory-card.jsx
+++ b/src/components/inventory/inventory-card.jsx
@@ -1,0 +1,157 @@
+import React, {useRef} from "react";
+import {formatInt, formatValue, secondsToString} from "../../general/utils/strings";
+import {TippyWrapper} from "../shared/tippy-wrapper.jsx";
+import CircularProgress from "../shared/circular-progress.jsx";
+import {BreakDown} from "../layout/sidebar.jsx";
+import {useFlashOnLevelUp} from "../../general/hooks/flash";
+import {NewNotificationWrap} from "../shared/new-notification-wrap.jsx";
+
+export const InventoryCard = React.memo(({ isChanged, eta, usages, usagesFor, allowMultiConsume, isConsumable, isRare, isRareIngredient, isSelected, id, name, amount, balance, breakDown, isConsumed, cooldownProg, cooldown, onFlash, onPurchase, onShowDetails, onEditConfig, isMobile}) => {
+    const elementRef = useRef(null);
+
+    useFlashOnLevelUp(isConsumed, onFlash, elementRef);
+
+    const handleClick = (e) => {
+        if (e.button === 0) {
+            onEditConfig({id, name});
+        }
+    };
+
+    const handleContextMenu = (e) => {
+        e.preventDefault();
+        if(!isConsumable) return;
+        let amt = 1;
+        if(allowMultiConsume) {
+            if(e.shiftKey) amt = amount;
+            if(e.ctrlKey && amount >= 1) amt = Math.max(0.1*amount, 1)
+        }
+        onPurchase(id, amt);
+    };
+
+    return (<div
+        id={`inventory-item-card-${id}`}
+        ref={elementRef}
+        className={`icon-card item bigger flashable ${isSelected ? 'selected' : ''} ${isRare ? 'bluish' : ''} ${isRareIngredient ? 'ingredient' : ''}`}
+        onMouseEnter={() => {
+            if (!isMobile) {
+                onShowDetails(id);
+            }
+        }}
+        onMouseLeave={() => {
+            if (!isMobile) {
+                onShowDetails(null);
+            }
+        }}
+        onClick={handleClick}
+        onContextMenu={handleContextMenu}
+    >
+        <TippyWrapper content={<div className={'hint-popup'}>
+            <p>{name}({formatInt(amount)})</p>
+            {usages?.length ? (<div className={'block'}>
+                <p>Used By:</p>
+                <div className={'sub-items'}>
+                    {usages.map(one => (<p className={'padded-left'}>{one.name}</p>))}
+                </div>
+            </div> ) : null}
+            {usagesFor?.length ? (<div className={'block'}>
+                <p>Used For:</p>
+                <div className={'sub-items'}>
+                    {usagesFor.map(one => (<p className={'padded-left'}>{one.name}</p>))}
+                </div>
+            </div> ) : null}
+            {breakDown ? (<BreakDown breakDown={breakDown}/>) : null}
+            <div className={'block'}>
+                <p>Balance: {formatValue(balance)}</p>
+                {balance < 0 ? (<p>{`${secondsToString(-eta)} to empty`}</p>) : null}
+            </div>
+            <p>Left click to select</p>
+            {isConsumable ? (<p>Right click to consume</p>) : null}
+            {isConsumable && allowMultiConsume && amount > 10 ? (<p>Right click + CTRL to consume {formatInt(0.1*amount)}</p>) : null}
+            {isConsumable && allowMultiConsume? (<p>Right click + SHIFT to consume all</p>) : null}
+        </div> }>
+            <div className={'icon-content'}>
+                <CircularProgress progress={cooldownProg}>
+                    <img src={`icons/resources/${id}.png`} className={'resource'} />
+                </CircularProgress>
+                <span className={'level'}>{formatValue(amount)}</span>
+            </div>
+        </TippyWrapper>
+
+    </div> )
+}, ((prevProps, currProps) => {
+    if(prevProps.id !== currProps.id) {
+        return false;
+    }
+
+    if(prevProps.amount !== currProps.amount) {
+        return false;
+    }
+
+    if(prevProps.eta !== currProps.eta && (currProps.eta < 0 || prevProps.eta < 0)) {
+        return false;
+    }
+
+    if(prevProps.cooldownProg !== currProps.cooldownProg) {
+        return false;
+    }
+
+    if(prevProps.isConsumed !== currProps.isConsumed) {
+        return false;
+    }
+
+    if(prevProps.isChanged !== currProps.isChanged) {
+        return false;
+    }
+
+    if(prevProps.isSelected !== currProps.isSelected) {
+        return false;
+    }
+    return true;
+}));
+
+const InventoryItemComponent = ({
+    item,
+    isChanged,
+    isMobile,
+    isSelected,
+    isNew,
+    onFlash,
+    onPurchase,
+    onShowDetails,
+    onEditConfig,
+}) => {
+    return (
+        <NewNotificationWrap
+            id={`inventory_${item.id}`}
+            className={'narrow-wrapper'}
+            isNew={isNew}
+        >
+            <InventoryCard
+                {...item}
+                isSelected={isSelected}
+                isChanged={isChanged}
+                onPurchase={onPurchase}
+                onFlash={onFlash}
+                onShowDetails={onShowDetails}
+                onEditConfig={onEditConfig}
+                isMobile={isMobile}
+            />
+        </NewNotificationWrap>
+    );
+};
+
+const areInventoryItemPropsEqual = (prev, next) => {
+    return (
+        prev.item === next.item &&
+        prev.isChanged === next.isChanged &&
+        prev.isMobile === next.isMobile &&
+        prev.isSelected === next.isSelected &&
+        prev.isNew === next.isNew &&
+        prev.onFlash === next.onFlash &&
+        prev.onPurchase === next.onPurchase &&
+        prev.onShowDetails === next.onShowDetails &&
+        prev.onEditConfig === next.onEditConfig
+    );
+};
+
+export const InventoryItem = React.memo(InventoryItemComponent, areInventoryItemPropsEqual);

--- a/src/components/inventory/inventory-card.jsx
+++ b/src/components/inventory/inventory-card.jsx
@@ -6,6 +6,9 @@ import {BreakDown} from "../layout/sidebar.jsx";
 import {useFlashOnLevelUp} from "../../general/hooks/flash";
 import {NewNotificationWrap} from "../shared/new-notification-wrap.jsx";
 
+const itemKeysToCompare = ['id', 'eta', 'cooldownProg', 'isConsumed', 'isChanged', 'isSelected', 'cooldownProg'];
+const itemKeysToCompareDelta = ['amount', 'balance']
+
 export const InventoryCard = React.memo(({ isChanged, eta, usages, usagesFor, allowMultiConsume, isConsumable, isRare, isRareIngredient, isSelected, id, name, amount, balance, breakDown, isConsumed, cooldownProg, cooldown, onFlash, onPurchase, onShowDetails, onEditConfig, isMobile}) => {
     const elementRef = useRef(null);
 
@@ -141,6 +144,18 @@ const InventoryItemComponent = ({
 };
 
 const areInventoryItemPropsEqual = (prev, next) => {
+    if(!prev.item || !next.item) return false;
+
+    itemKeysToCompare.forEach(key => {
+        if(prev.item[key] !== next.item[key]) {
+            return false;
+        }
+    });
+    itemKeysToCompareDelta.forEach(key => {
+        if(Math.abs(1 -(prev.item[key] / (next.item[key] + 1.e-6))) > 1.e-3) {
+            return false;
+        }
+    });
     return (
         prev.item === next.item &&
         prev.isChanged === next.isChanged &&

--- a/src/components/inventory/inventory-details.jsx
+++ b/src/components/inventory/inventory-details.jsx
@@ -1,0 +1,268 @@
+import React, {useContext, useEffect, useState} from "react";
+import PerfectScrollbar from "react-perfect-scrollbar";
+import {formatInt, formatValue, secondsToString} from "../../general/utils/strings";
+import {EffectsSection} from "../shared/effects-section.jsx";
+import {ResourceComparison} from "../shared/resource-comparison.jsx";
+import {CustomButton} from "../shared/buttons/custom-button.jsx";
+import {useTutorial} from "../../context/tutorial-context";
+import WorkerContext from "../../context/worker-context";
+import {useWorkerClient} from "../../general/client";
+import {PinResource} from "../shared/pin-resource.jsx";
+import RulesList from "../shared/rules-list.jsx";
+
+export const InventoryDetails = React.memo(({isChanged, editData, viewedData, resources, onAddAutoconsumeRule, onSetAutoconsumeRuleValue, onDeleteAutoconsumeRule, onAddAutosellRule, onSetAutosellRuleValue, onDeleteAutosellRule, onSave, onCancel, onSell, onSetAutosellPattern, onSetAutoconsumePattern, onSetAutosellReserved, onSetAutoconsumeReserved, onToggleAutoconsume, onToggleAutosell, automationUnlocked, onConsume, onToggleViewLasting}) => {
+
+    const worker = useContext(WorkerContext);
+
+    const { sendData, onMessage, removeMessage } = useWorkerClient(worker);
+
+    const { unlockNextById, currentTourId } = useTutorial();
+
+    const [details, setDetails] = useState(null);
+
+    const item = viewedData ? viewedData : editData;
+
+    let isEditing = !!editData && !viewedData;
+
+    if(!item) return null;
+
+    useEffect(() => {
+
+        if(item) {
+            sendData('query-inventory-details', { id: item.id, prefix: 'detail-blade' })
+        }
+    }, [item, sendData]);
+
+    useEffect(() => {
+        if(currentTourId === 'inventory' && details?.id === 'inventory_brightleaf') {
+            unlockNextById(14);
+        }
+    }, [currentTourId, details?.id, details?.numConsumed, details?.currentDuration, unlockNextById]);
+
+    useEffect(() => {
+        onMessage('detail-blade-inventory-details', (data) => {
+            setDetails(data);
+        });
+
+        return () => {
+            removeMessage('detail-blade-inventory-details');
+        };
+    }, [onMessage, removeMessage]);
+
+    const setAutoconsumePattern = (pattern) => {
+      onSetAutoconsumePattern(pattern)
+    }
+
+    const addAutoconsumeRule = () => {
+        onAddAutoconsumeRule()
+    }
+
+    const setAutoconsumeRuleValue = (index, key, value) => {
+        onSetAutoconsumeRuleValue(index, key, value)
+    }
+
+    const deleteAutoconsumeRule = (index) => {
+        onDeleteAutoconsumeRule(index)
+    }
+
+    const setAutosellPattern = (pattern) => {
+        onSetAutosellPattern(pattern)
+    }
+
+    const addAutosellRule = () => {
+        onAddAutosellRule()
+    }
+
+    const setAutosellRuleValue = (index, key, value) => {
+        onSetAutosellRuleValue(index, key, value)
+    }
+
+    const deleteAutosellRule = (index) => {
+        onDeleteAutosellRule(index)
+    }
+
+    const setReservedValue = (reserved) => {
+        onSetAutosellReserved(reserved)
+    }
+
+    const setReservedConsumeValue = (reserved) => {
+        onSetAutoconsumeReserved(reserved)
+    }
+
+    const toggleAutosell = () => {
+        onToggleAutosell()
+    }
+
+    const toggleAutoconsume = () => {
+        onToggleAutoconsume()
+    }
+
+    const consumeItem = () => {
+        if(currentTourId === 'inventory' && item.id === 'inventory_brightleaf') {
+            unlockNextById(14);
+        }
+        onConsume(item.id);
+    }
+
+    const toggleViewLasting = () => {
+        onToggleViewLasting(item.id, !(details || item).show_lasting);
+    }
+
+    if(currentTourId === 'inventory' && item.id === 'inventory_brightleaf' && isEditing) {
+        unlockNextById(11);
+    }
+
+    return (
+        <>
+            <div className={'blade-outer'}>
+                <PerfectScrollbar>
+                    <div className={'blade-inner inventory-items-blade'}>
+                        <div className={'block'}>
+                            <div className={'inner-heading flex-container flex-row'}>
+                                <h4>{item.name} (x{formatInt(item.amount)})</h4>
+                                <PinResource id={item.id} isPinned={details?.isPinned} />
+                            </div>
+
+                            <div className={'description'}>
+                                {item.description}
+                            </div>
+                        </div>
+                        <div className={'block'}>
+                            <div className={'tags-container'}>
+                                {item.tags.map(tag => (<div key={tag} className={'tag'}>{tag}</div> ))}
+                            </div>
+                        </div>
+                        {item?.effects?.length ? (<div className={'block'}>
+                            <p>Effects on usage:</p>
+                            <div className={'effects'}>
+                                <EffectsSection effects={item.effects}/>
+                            </div>
+                        </div>) : null}
+                        {item.potentialPermanentEffects ? (<div className={'block'}>
+                            <p>Permanent Effects:</p>
+                            <div className={'effects'}>
+                                <ResourceComparison effects1={item.permanentEffects} effects2={item.potentialPermanentEffects}/>
+                            </div>
+                        </div>) : null}
+                        {item.duration ? (<div className={'block'}>
+                            <p>Effects lasting: {secondsToString(item.duration)}</p>
+                            <div className={'effects'}>
+                                <EffectsSection effects={item.potentialEffects} />
+                            </div>
+                            {item.canShowLasting ? (<div className={'show-lasting'}>
+                                <CustomButton
+                                    iconId={'icon_view_lasting'}
+                                    className={`toggle-effect-monitor medium-sm ${details?.show_lasting ? 'highlighted' : ''}`}
+                                    onClick={(e) => {toggleViewLasting()}}
+                                >{details?.show_lasting ? 'Stop showing active effects in left sidebar' : 'Show when active in left sidebar'}</CustomButton>
+                            </div> ) : null}
+                        </div>) : null}
+
+                        <div className={'block'}>
+                            {item.isConsumable ? (<div className={'flex-container consumption-block'}>
+                                <div className={'stats'}>
+                                    <p>Consumption Cooldown: {secondsToString(item.consumptionCooldown)}</p>
+                                    <p>Consumed amount: {formatInt(item.numConsumed)}</p>
+                                </div>
+                                <div className={'consume-block'}>
+                                    <button className={'consume-button'} onClick={consumeItem} disabled={details?.currentCooldown > 0 || details?.currentDuration > 0}>Consume</button>
+                                    {details?.currentDuration ? (<p className={'small'}>Running: {secondsToString(details?.currentDuration)}</p>) : null}
+                                    {details?.currentCooldown ? (<p className={'small'}>Cooldown: {secondsToString(details?.currentCooldown)}</p>) : null}
+                                </div>
+                            </div>) : null}
+                            {item.isSellable ? (<div>
+                                <p>Sold amount: {formatInt(item.soldAmount)}</p>
+                                <p>Coins Earned: {formatInt(item.coinsEarned)}</p>
+                            </div>) : null}
+                        </div>
+
+                        {item.isConsumable && automationUnlocked ? (<div className={'autoconsume-setting block'}>
+                            <div className={'rules-header flex-container'}>
+                                <p>Autoconsumption rules: {item.autoconsume?.rules?.length ? null : 'None'}</p>
+                                <label>
+                                    <input type={'checkbox'} checked={item.autoconsume?.isEnabled ?? undefined} onChange={toggleAutoconsume}/>
+                                    {item.autoconsume?.isEnabled ? ' ON' : ' OFF'}
+                                </label>
+                                {isEditing ? (<button onClick={addAutoconsumeRule}>Add rule (AND)</button>) : null}
+                            </div>
+
+                            <RulesList
+                                prefix={'autoconsume'}
+                                isEditing={isEditing}
+                                rules={item.autoconsume?.rules || []}
+                                resources={resources}
+                                pattern={item.autoconsume?.pattern}
+                                deleteRule={deleteAutoconsumeRule}
+                                setRuleValue={setAutoconsumeRuleValue}
+                                setPattern={setAutoconsumePattern}
+                                isAutoCheck={item.autoconsume?.isEnabled}
+                            />
+                            <div className={'autoconsume-amount flex-container'}>
+                                <p>Reserved Amount:</p>
+                                {isEditing ? <input type={'number'} onChange={e => setReservedConsumeValue(+e.target.value)}
+                                        value={item.autoconsume?.reserved || 0}/> : <span>{formatValue(item.autoconsume?.reserved || 0)}</span>}
+                            </div>
+                        </div>) : null}
+
+                        {item.isSellable && automationUnlocked ? (<div className={'autoconsume-setting block'}>
+                            <div className={'rules-header flex-container'}>
+                                <p>Autosell rules: {item.autosell?.rules?.length ? null : 'None'}</p>
+                                <label>
+                                    <input type={'checkbox'} checked={item.autosell?.isEnabled ?? undefined} onChange={toggleAutosell}/>
+                                    {item.autosell?.isEnabled ? ' ON' : ' OFF'}
+                                </label>
+                                {isEditing ? (<button onClick={addAutosellRule}>Add rule (AND)</button>) : null}
+                            </div>
+
+                            <RulesList
+                                prefix={'autosell'}
+                                isEditing={isEditing}
+                                rules={item.autosell?.rules || []}
+                                pattern={item.autosell?.pattern}
+                                resources={resources}
+                                deleteRule={deleteAutosellRule}
+                                setRuleValue={setAutosellRuleValue}
+                                setPattern={setAutosellPattern}
+                                isAutoCheck={item.autosell?.isEnabled}
+                            />
+                            <div className={'autosell-amount flex-container'}>
+                                <p>Reserved Amount:</p>
+                                {isEditing ? <input type={'number'} onChange={e => setReservedValue(+e.target.value)}
+                                        value={item.autosell?.reserved || 0}/> : <span>{formatValue(item.autosell?.reserved || 0)}</span>}
+                            </div>
+                        </div>) : null}
+
+                        {item.isSellable ? (<div className={'block sell-block'}>
+                            <p className={'text-desc'}>Sell price: {formatValue(item.sellPrice)}</p>
+                            <div className={'buttons flex-container'}>
+                                <button disabled={item.maxSell < 1} onClick={() => onSell(item.id, 1)}>Sell</button>
+                                <button disabled={item.maxSell < 1} onClick={() => onSell(item.id, item.maxSell)}>Sell max (x{formatInt(item.maxSell)})</button>
+                            </div>
+                        </div> ) : null}
+
+
+                    </div>
+                </PerfectScrollbar>
+            </div>
+            {isEditing ? (<div className={'buttons flex-container main-buttons'}>
+                <button className={'primary-action'} disabled={!isChanged} onClick={onSave}>Save</button>
+                <button className={'warning-action'} onClick={onCancel}>Cancel</button>
+            </div>) : null}
+        </>
+    )
+}, (prevProps, currentProps) => {
+
+    if(prevProps.isChanged !== currentProps.isChanged) {
+        return false;
+    }
+
+    if(prevProps.editData !== currentProps.editData) {
+        return false;
+    }
+
+    if(prevProps.viewedData !== currentProps.viewedData) {
+        return false;
+    }
+
+    return true;
+});

--- a/src/components/inventory/inventory-stats.jsx
+++ b/src/components/inventory/inventory-stats.jsx
@@ -1,0 +1,40 @@
+import React, {useCallback} from "react";
+import PerfectScrollbar from "react-perfect-scrollbar";
+import {useAppContext} from "../../context/ui-context";
+import StatRow from "../shared/stat-row.jsx";
+
+export const InventoryStats = ({ details, setDetailVisible }) => {
+
+    const { isMobile } = useAppContext();
+    const statsToDisplay = [
+        details.bargaining,
+        details.bargaining_mod,
+        details.shop_max_stock,
+        details.shop_stock_renew_rate,
+    ];
+
+    const hasEffect = useCallback((stat) => {
+        if(!stat?.value) return false;
+        return !stat.isMultiplier || Math.abs(stat?.value - 1.0) > 1.e-7;
+    }, [])
+
+    return (
+        <PerfectScrollbar>
+            <div className={'blade-inner'}>
+                <div className={'block'}>
+                    <p>General Stats:</p>
+                    <div className={'effects'}>
+                        {statsToDisplay.map((stat) => (
+                            hasEffect(stat) ? (
+                                <StatRow key={stat.id} stat={stat} />
+                            ) : null
+                        ))}
+                    </div>
+                </div>
+                {isMobile ? (<div className={'block buttons'}>
+                    <button onClick={() => setDetailVisible(false)}>Close</button>
+                </div>) : null}
+            </div>
+        </PerfectScrollbar>
+    );
+};

--- a/src/components/inventory/inventory.jsx
+++ b/src/components/inventory/inventory.jsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useEffect, useRef, useState} from "react";
+import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from "react";
 import WorkerContext from "../../context/worker-context";
 import {useWorkerClient} from "../../general/client";
 import {formatInt, formatValue, secondsToString} from "../../general/utils/strings";
@@ -37,6 +37,160 @@ const INVENTORY_SEARCH_SCOPES = [{
     id: 'effects',
     label: 'effects'
 }]
+
+const areArraysEqualByKey = (prev = [], next = [], key) => {
+    const prevList = prev ?? [];
+    const nextList = next ?? [];
+    if(prevList === nextList) {
+        return true;
+    }
+    if(prevList.length !== nextList.length) {
+        return false;
+    }
+    for(let i = 0; i < prevList.length; i += 1) {
+        const prevValue = key ? prevList[i]?.[key] : prevList[i];
+        const nextValue = key ? nextList[i]?.[key] : nextList[i];
+        if(prevValue !== nextValue) {
+            return false;
+        }
+    }
+    return true;
+};
+
+const hasMeaningfulItemChanges = (prevItem, nextItem) => {
+    if(!prevItem) {
+        return true;
+    }
+    if(prevItem.id !== nextItem.id) {
+        return true;
+    }
+    const comparableKeys = ['amount', 'balance', 'eta', 'cooldownProg', 'cooldown', 'isConsumed', 'isConsumable', 'allowMultiConsume', 'isRare', 'isRareIngredient'];
+    if(comparableKeys.some(key => prevItem[key] !== nextItem[key])) {
+        return true;
+    }
+    if(prevItem.name !== nextItem.name) {
+        return true;
+    }
+    if(!areArraysEqualByKey(prevItem.usages, nextItem.usages, 'id')) {
+        return true;
+    }
+    if(!areArraysEqualByKey(prevItem.usagesFor, nextItem.usagesFor, 'id')) {
+        return true;
+    }
+    if(prevItem.breakDown !== nextItem.breakDown) {
+        return true;
+    }
+    return false;
+};
+
+const mergeInventoryItems = (nextItems = [], prevItems = []) => {
+    if(!prevItems.length) {
+        return nextItems;
+    }
+    const prevMap = new Map(prevItems.map(item => [item.id, item]));
+    let mutated = nextItems.length !== prevItems.length;
+    const merged = nextItems.map(item => {
+        const prevItem = prevMap.get(item.id);
+        if(prevItem && !hasMeaningfulItemChanges(prevItem, item)) {
+            return prevItem;
+        }
+        mutated = true;
+        return item;
+    });
+    return mutated ? merged : prevItems;
+};
+
+const hasCategoryChanges = (prevCategory, nextCategory) => {
+    if(!prevCategory) {
+        return true;
+    }
+    if(prevCategory.id !== nextCategory.id) {
+        return true;
+    }
+    if(prevCategory.name !== nextCategory.name) {
+        return true;
+    }
+    if(prevCategory.isSelected !== nextCategory.isSelected) {
+        return true;
+    }
+    const prevLength = prevCategory.items?.length ?? 0;
+    const nextLength = nextCategory.items?.length ?? 0;
+    return prevLength !== nextLength;
+};
+
+const mergeCategories = (nextCategories = [], prevCategories = []) => {
+    if(!prevCategories.length) {
+        return nextCategories;
+    }
+    const prevMap = new Map(prevCategories.map(category => [category.id, category]));
+    let mutated = nextCategories.length !== prevCategories.length;
+    const merged = nextCategories.map(category => {
+        const prevCategory = prevMap.get(category.id);
+        if(prevCategory && !hasCategoryChanges(prevCategory, category)) {
+            return prevCategory;
+        }
+        mutated = true;
+        return category;
+    });
+    return mutated ? merged : prevCategories;
+};
+
+const areSearchDataEqual = (prevSearch = {}, nextSearch = {}) => {
+    if(prevSearch === nextSearch) {
+        return true;
+    }
+    if((prevSearch?.search ?? '') !== (nextSearch?.search ?? '')) {
+        return false;
+    }
+    return areArraysEqualByKey(prevSearch?.selectedScopes ?? [], nextSearch?.selectedScopes ?? []);
+};
+
+const EFFECT_KEYS = ['bargaining', 'bargaining_mod', 'shop_max_stock', 'shop_stock_renew_rate'];
+
+const areEffectStatsEqual = (prevDetails = {}, nextDetails = {}) => {
+    if(prevDetails === nextDetails) {
+        return true;
+    }
+    return EFFECT_KEYS.every(key => {
+        const prev = prevDetails?.[key];
+        const next = nextDetails?.[key];
+        if(prev === next) {
+            return true;
+        }
+        if(!prev || !next) {
+            return false;
+        }
+        return prev.value === next.value && prev.isMultiplier === next.isMultiplier;
+    });
+};
+
+const mergeInventoryState = (prevState, nextState) => {
+    if(!prevState || (!prevState.available?.length && !prevState.itemCategories?.length)) {
+        return nextState;
+    }
+    const mergedAvailable = mergeInventoryItems(nextState.available, prevState.available);
+    const mergedCategories = mergeCategories(nextState.itemCategories, prevState.itemCategories);
+    const mergedSearchData = areSearchDataEqual(prevState.searchData, nextState.searchData) ? prevState.searchData : nextState.searchData;
+    const mergedDetails = areEffectStatsEqual(prevState.details, nextState.details) ? prevState.details : nextState.details;
+    const didChange =
+        mergedAvailable !== prevState.available ||
+        mergedCategories !== prevState.itemCategories ||
+        mergedSearchData !== prevState.searchData ||
+        mergedDetails !== prevState.details ||
+        prevState.selectedFilterId !== nextState.selectedFilterId ||
+        prevState.current !== nextState.current ||
+        prevState.automationUnlocked !== nextState.automationUnlocked;
+    if(!didChange) {
+        return prevState;
+    }
+    return {
+        ...nextState,
+        available: mergedAvailable,
+        itemCategories: mergedCategories,
+        searchData: mergedSearchData,
+        details: mergedDetails,
+    };
+};
 
 export const Inventory = ({}) => {
 
@@ -137,9 +291,9 @@ export const Inventory = ({}) => {
 
     useEffect(() => {
         onMessage('inventory-data', (inventory) => {
-            setItemsData(inventory);
+            setItemsData(prev => mergeInventoryState(prev, inventory));
         });
-        
+
         return () => {
             removeMessage('inventory-data');
         };
@@ -181,12 +335,11 @@ export const Inventory = ({}) => {
     const purchaseItem = useCallback((id, amount = 1) => {
         sendData('consume-inventory', { id, amount, sendDetails: true });
         // sendData('query-inventory-details', { id, amount: 1 })
-    })
+    }, [sendData])
 
     const setInventoryDetailsEdit = useCallback(({id, name}) => {
         if(id) {
             if(detailOpenedId && isChanged) {
-                console.log('detOpenedId: ', detailOpenedId, id);
                 confirm({
                     title: "Switch Item",
                     message: `You have unsaved changes to ${detailOpenedId.name}. Do you want to continue to the new item (losing current changes) or stay here?`,
@@ -217,7 +370,7 @@ export const Inventory = ({}) => {
                 playSound('click');
             }
         }
-    }, [isChanged, detailOpenedId])
+    }, [confirm, detailOpenedId, isChanged])
 
     const setInventoryDetailsView = useCallback((id) => {
         if (!id) {
@@ -259,7 +412,7 @@ export const Inventory = ({}) => {
             setEditData(newEdit);
             setChanged(true);
         }
-    }, [editData])
+    }, [editData, resources])
 
     const onSetAutoconsumeRuleValue = useCallback((index, key, value) => {
         if(editData) {
@@ -369,7 +522,7 @@ export const Inventory = ({}) => {
             setEditData(newEdit);
             setChanged(true);
         }
-    }, [editData])
+    }, [editData, viewedData])
 
     const onSetAutosellRuleValue = useCallback((index, key, value) => {
         if(editData) {
@@ -395,7 +548,7 @@ export const Inventory = ({}) => {
     const onSave = useCallback(() => {
         sendData('save-inventory-settings', editData);
         setChanged(false);
-    })
+    }, [editData, sendData])
 
     const onCancel = useCallback(() => {
         setViewedOpenedId(null);
@@ -407,33 +560,62 @@ export const Inventory = ({}) => {
 
     const onSell = useCallback((id, amount) => {
         sendData('sell-inventory', { id, amount });
-    })
+    }, [sendData])
 
     const [overlayPositions, setOverlayPositions] = useState([]);
 
-    const handleFlash = (position) => {
+    const handleFlash = useCallback((position) => {
         setOverlayPositions((prev) => [...prev, position]);
         setTimeout(() => {
             setOverlayPositions((prev) => prev.filter((p) => p !== position));
         }, 1000);
-    };
+    }, [])
 
 
-    const setItemsFilter = (filterId) => {
+    const setItemsFilter = useCallback((filterId) => {
         sendData('set-selected-inventory-filter', { filterId })
-    }
+    }, [sendData])
 
-    const setSearch = (searchData) => {
+    const setSearch = useCallback((searchData) => {
         sendData('set-inventory-search', { searchData });
-    }
+    }, [sendData])
 
-    const onTogglePinned = (id, flag) => {
+    const onTogglePinned = useCallback((id, flag) => {
         sendData('set-resource-pinned', { id, flag });
-    }
+    }, [sendData])
 
-    const onToggleViewLasting = (id, flag) => {
+    const onToggleViewLasting = useCallback((id, flag) => {
         sendData('set-lasting-pinned', { id, flag });
-    }
+    }, [sendData])
+
+    const selectedFilterId = inventoryData.selectedFilterId;
+    const selectedItemId = detailOpenedId?.id ?? null;
+    const categoryUnlocks = useMemo(() => newUnlocks.inventory?.items?.all?.items || {}, [newUnlocks]);
+    const selectedFilterUnlocks = useMemo(() => categoryUnlocks[selectedFilterId]?.items || {}, [categoryUnlocks, selectedFilterId]);
+
+    const categoriesMenu = useMemo(() => inventoryData.itemCategories.map(category => (
+        <li key={category.id} className={`category ${category.isSelected ? 'active' : ''}`} onClick={() => setItemsFilter(category.id)}>
+            <NewNotificationWrap isNew={categoryUnlocks?.[category.id]?.hasNew}>
+                <span>{category.name}({category.items.length})</span>
+            </NewNotificationWrap>
+        </li>
+    )), [categoryUnlocks, inventoryData.itemCategories, setItemsFilter])
+
+    const inventoryItems = useMemo(() => inventoryData.available.map(item => (
+        <NewNotificationWrap key={`inventory_${item.id}`} id={`inventory_${item.id}`} className={'narrow-wrapper'} isNew={selectedFilterUnlocks?.[`inventory_${item.id}`]?.hasNew}>
+            <InventoryCard
+                key={item.id}
+                isSelected={item.id === selectedItemId}
+                isChanged={isChanged}
+                {...item}
+                onPurchase={purchaseItem}
+                onFlash={handleFlash}
+                onShowDetails={setInventoryDetailsView}
+                onEditConfig={setInventoryDetailsEdit}
+                isMobile={isMobile}
+            />
+        </NewNotificationWrap>
+    )), [handleFlash, inventoryData.available, isChanged, isMobile, purchaseItem, selectedFilterUnlocks, selectedItemId, setInventoryDetailsEdit, setInventoryDetailsView])
 
     if(currentTourId === 'inventory') {
         unlockNextById(9);
@@ -444,11 +626,7 @@ export const Inventory = ({}) => {
             <div className={'ingame-box inventory'}>
                 <div className={'categories flex-container'}>
                     <ul className={'menu'}>
-                        {inventoryData.itemCategories.map(category => (<li key={category.id} className={`category ${category.isSelected ? 'active' : ''}`} onClick={() => setItemsFilter(category.id)}>
-                            <NewNotificationWrap isNew={newUnlocks.inventory?.items?.all?.items?.[category.id]?.hasNew}>
-                                <span>{category.name}({category.items.length})</span>
-                            </NewNotificationWrap>
-                        </li> ))}
+                        {categoriesMenu}
                     </ul>
                     <div className={'additional-filters'}>
                         <label>
@@ -469,18 +647,7 @@ export const Inventory = ({}) => {
                 <div className={'inventory-items-wrap'}>
                     <PerfectScrollbar>
                         <div className={'flex-container'}>
-                            {inventoryData.available.map(item => <NewNotificationWrap key={`inventory_${item.id}`} id={`inventory_${item.id}`} className={'narrow-wrapper'} isNew={newUnlocks.inventory?.items?.all?.items?.[inventoryData.selectedFilterId]?.items?.[`inventory_${item.id}`]?.hasNew}>
-                                <InventoryCard
-                                    key={item.id}
-                                    isSelected={item.id === detailOpenedId?.id}
-                                    isChanged={isChanged}
-                                    {...item}
-                                    onPurchase={purchaseItem}
-                                    onFlash={handleFlash}
-                                    onShowDetails={setInventoryDetailsView}
-                                    onEditConfig={setInventoryDetailsEdit}
-                                    isMobile={isMobile}
-                                /></NewNotificationWrap>)}
+                            {inventoryItems}
                             {overlayPositions.map((position, index) => (
                                 <FlashOverlay key={index} position={position} />
                             ))}
@@ -730,8 +897,6 @@ export const InventoryDetails = React.memo(({isChanged, editData, viewedData, re
     if(currentTourId === 'inventory' && item.id === 'inventory_brightleaf' && isEditing) {
         unlockNextById(11);
     }
-
-    console.log('editData: ', editData, viewedData);
 
     return (
         <>

--- a/src/components/inventory/inventory.jsx
+++ b/src/components/inventory/inventory.jsx
@@ -1,27 +1,20 @@
-import React, {useCallback, useContext, useEffect, useMemo, useRef, useState} from "react";
+import React, {useCallback, useContext, useEffect, useMemo, useState} from "react";
 import WorkerContext from "../../context/worker-context";
 import {useWorkerClient} from "../../general/client";
-import {formatInt, formatValue, secondsToString} from "../../general/utils/strings";
 import PerfectScrollbar from "react-perfect-scrollbar";
-import {EffectsSection} from "../shared/effects-section.jsx";
-import CircularProgress from "../shared/circular-progress.jsx";
 import {FlashOverlay} from "../layout/flash-overlay.jsx";
-import {useFlashOnLevelUp} from "../../general/hooks/flash";
-import {isOverTippyEvent, TippyWrapper} from "../shared/tippy-wrapper.jsx";
-import RulesList from "../shared/rules-list.jsx";
 import {cloneDeep} from "lodash";
-import {BreakDown} from "../layout/sidebar.jsx";
-import {ResourceComparison} from "../shared/resource-comparison.jsx";
 import {NewNotificationWrap} from "../shared/new-notification-wrap.jsx";
-import StatRow from "../shared/stat-row.jsx";
 import {SearchField} from "../shared/search-field.jsx";
 import {useAppContext} from "../../context/ui-context";
-import {PinResource} from "../shared/pin-resource.jsx";
-import {CustomButton} from "../shared/buttons/custom-button.jsx";
 import {useModal} from "../../general/components/modal/index.jsx";
 import {HowToSign} from "../shared/how-to-sign.jsx";
 import {useTutorial} from "../../context/tutorial-context";
 import {playSound} from "../../context/sounds/sound-manager";
+import {InventoryDetails} from "./inventory-details.jsx";
+import {InventoryStats} from "./inventory-stats.jsx";
+import {InventoryItem} from "./inventory-card.jsx";
+import {getInventorySnapshot, updateInventoryState, useInventoryData} from "../../state/inventory-store";
 
 
 const INVENTORY_SEARCH_SCOPES = [{
@@ -192,26 +185,28 @@ const mergeInventoryState = (prevState, nextState) => {
     };
 };
 
+const selectAvailableItems = state => state?.available ?? [];
+const selectItemCategories = state => state?.itemCategories ?? [];
+const selectSelectedFilterId = state => state?.selectedFilterId ?? 'all';
+const selectAutomationUnlocked = state => !!state?.automationUnlocked;
+const selectInventoryDetails = state => state?.details ?? {};
+const selectInventorySearchData = state => state?.searchData ?? { search: '', selectedScopes: ['name', 'tags'] };
+
 export const Inventory = ({}) => {
 
     const worker = useContext(WorkerContext);
     const { isMobile } = useAppContext();
     const [isDetailVisible, setDetailVisible] = useState(!isMobile);
-    const { stepIndex, unlockNextById, jumpOver, currentTourId } = useTutorial();
+    const { unlockNextById, currentTourId } = useTutorial();
 
     const { onMessage, sendData, removeMessage } = useWorkerClient(worker);
     const { confirm } = useModal();
-    const [inventoryData, setItemsData] = useState({
-        available: [],
-        current: undefined,
-        itemCategories: [],
-        selectedFilterId: 'all',
-        automationUnlocked: false,
-        details: {},
-        searchData: {
-            search: ''
-        }
-    });
+    const availableItems = useInventoryData(selectAvailableItems);
+    const itemCategories = useInventoryData(selectItemCategories);
+    const selectedFilterId = useInventoryData(selectSelectedFilterId);
+    const automationUnlocked = useInventoryData(selectAutomationUnlocked);
+    const inventoryDetails = useInventoryData(selectInventoryDetails);
+    const searchValue = useInventoryData(selectInventorySearchData);
     const [detailOpenedId, setDetailOpenedId] = useState(null); // here should be object containing id and rules
     const [viewedOpenedId, setViewedOpenedId] = useState(null);
     const [editData, setEditData] = useState(null);
@@ -291,7 +286,9 @@ export const Inventory = ({}) => {
 
     useEffect(() => {
         onMessage('inventory-data', (inventory) => {
-            setItemsData(prev => mergeInventoryState(prev, inventory));
+            const prev = getInventorySnapshot();
+            const merged = mergeInventoryState(prev, inventory);
+            updateInventoryState(merged);
         });
 
         return () => {
@@ -580,42 +577,36 @@ export const Inventory = ({}) => {
         sendData('set-inventory-search', { searchData });
     }, [sendData])
 
-    const onTogglePinned = useCallback((id, flag) => {
-        sendData('set-resource-pinned', { id, flag });
-    }, [sendData])
-
     const onToggleViewLasting = useCallback((id, flag) => {
         sendData('set-lasting-pinned', { id, flag });
     }, [sendData])
 
-    const selectedFilterId = inventoryData.selectedFilterId;
     const selectedItemId = detailOpenedId?.id ?? null;
     const categoryUnlocks = useMemo(() => newUnlocks.inventory?.items?.all?.items || {}, [newUnlocks]);
     const selectedFilterUnlocks = useMemo(() => categoryUnlocks[selectedFilterId]?.items || {}, [categoryUnlocks, selectedFilterId]);
 
-    const categoriesMenu = useMemo(() => inventoryData.itemCategories.map(category => (
+    const categoriesMenu = useMemo(() => itemCategories.map(category => (
         <li key={category.id} className={`category ${category.isSelected ? 'active' : ''}`} onClick={() => setItemsFilter(category.id)}>
             <NewNotificationWrap isNew={categoryUnlocks?.[category.id]?.hasNew}>
                 <span>{category.name}({category.items.length})</span>
             </NewNotificationWrap>
         </li>
-    )), [categoryUnlocks, inventoryData.itemCategories, setItemsFilter])
+    )), [categoryUnlocks, itemCategories, setItemsFilter])
 
-    const inventoryItems = useMemo(() => inventoryData.available.map(item => (
-        <NewNotificationWrap key={`inventory_${item.id}`} id={`inventory_${item.id}`} className={'narrow-wrapper'} isNew={selectedFilterUnlocks?.[`inventory_${item.id}`]?.hasNew}>
-            <InventoryCard
-                key={item.id}
-                isSelected={item.id === selectedItemId}
-                isChanged={isChanged}
-                {...item}
-                onPurchase={purchaseItem}
-                onFlash={handleFlash}
-                onShowDetails={setInventoryDetailsView}
-                onEditConfig={setInventoryDetailsEdit}
-                isMobile={isMobile}
-            />
-        </NewNotificationWrap>
-    )), [handleFlash, inventoryData.available, isChanged, isMobile, purchaseItem, selectedFilterUnlocks, selectedItemId, setInventoryDetailsEdit, setInventoryDetailsView])
+    const inventoryItems = useMemo(() => availableItems.map(item => (
+        <InventoryItem
+            key={item.id}
+            item={item}
+            isSelected={item.id === selectedItemId}
+            isChanged={isChanged}
+            isNew={selectedFilterUnlocks?.[`inventory_${item.id}`]?.hasNew}
+            onPurchase={purchaseItem}
+            onFlash={handleFlash}
+            onShowDetails={setInventoryDetailsView}
+            onEditConfig={setInventoryDetailsEdit}
+            isMobile={isMobile}
+        />
+    )), [availableItems, handleFlash, isChanged, isMobile, purchaseItem, selectedFilterUnlocks, selectedItemId, setInventoryDetailsEdit, setInventoryDetailsView])
 
     if(currentTourId === 'inventory') {
         unlockNextById(9);
@@ -632,7 +623,7 @@ export const Inventory = ({}) => {
                         <label>
                             <SearchField
                                 placeholder={'Search'}
-                                value={inventoryData.searchData || ''}
+                                value={searchValue || ''}
                                 onSetValue={val => setSearch(val)}
                                 scopes={INVENTORY_SEARCH_SCOPES}
                             />
@@ -676,422 +667,13 @@ export const Inventory = ({}) => {
                     onSave={onSave}
                     onCancel={onCancel}
                     onSell={onSell}
-                    automationUnlocked={inventoryData.automationUnlocked}
+                    automationUnlocked={automationUnlocked}
                     onConsume={purchaseItem}
-                    onTogglePinned={onTogglePinned}
                     onToggleViewLasting={onToggleViewLasting}
-                />) : (<InventoryStats details={inventoryData.details} setDetailVisible={setDetailVisible}/>)}
+                />) : (<InventoryStats details={inventoryDetails} setDetailVisible={setDetailVisible}/>)}
             </div>) : null}
         </div>
 
     )
 
 }
-
-export const InventoryCard = React.memo(({ isChanged, eta, usages, usagesFor, allowMultiConsume, isConsumable, isRare, isRareIngredient, isSelected, id, name, amount, balance, breakDown, isConsumed, cooldownProg, cooldown, onFlash, onPurchase, onShowDetails, onEditConfig, isMobile}) => {
-    const elementRef = useRef(null);
-
-    useFlashOnLevelUp(isConsumed, onFlash, elementRef);
-
-    const handleClick = (e) => {
-        if (e.button === 0) {
-            // Left-click
-            onEditConfig({id, name});
-        }
-    };
-
-    const handleContextMenu = (e) => {
-        e.preventDefault(); // Prevents the default context menu
-        if(!isConsumable) return;
-        let amt = 1;
-        if(allowMultiConsume) {
-            if(e.shiftKey) amt = amount;
-            if(e.ctrlKey && amount >= 1) amt = Math.max(0.1*amount, 1)
-        }
-        onPurchase(id, amt); // Your custom right-click action
-    };
-
-    return (<div
-        id={`inventory-item-card-${id}`}
-        ref={elementRef}
-        className={`icon-card item bigger flashable ${isSelected ? 'selected' : ''} ${isRare ? 'bluish' : ''} ${isRareIngredient ? 'ingredient' : ''}`}
-        onMouseEnter={() => {
-            if (!isMobile) {
-                onShowDetails(id);
-            }
-        }}
-        onMouseLeave={() => {
-            if (!isMobile) {
-                onShowDetails(null);
-            }
-        }}
-        onClick={handleClick}
-        onContextMenu={handleContextMenu}
-    >
-        <TippyWrapper content={<div className={'hint-popup'}>
-            <p>{name}({formatInt(amount)})</p>
-            {usages?.length ? (<div className={'block'}>
-                <p>Used By:</p>
-                <div className={'sub-items'}>
-                    {usages.map(one => (<p className={'padded-left'}>{one.name}</p>))}
-                </div>
-            </div> ) : null}
-            {usagesFor?.length ? (<div className={'block'}>
-                <p>Used For:</p>
-                <div className={'sub-items'}>
-                    {usagesFor.map(one => (<p className={'padded-left'}>{one.name}</p>))}
-                </div>
-            </div> ) : null}
-            {breakDown ? (<BreakDown breakDown={breakDown}/>) : null}
-            <div className={'block'}>
-                <p>Balance: {formatValue(balance)}</p>
-                {balance < 0 ? (<p>{`${secondsToString(-eta)} to empty`}</p>) : null}
-            </div>
-            <p>Left click to select</p>
-            {isConsumable ? (<p>Right click to consume</p>) : null}
-            {isConsumable && allowMultiConsume && amount > 10 ? (<p>Right click + CTRL to consume {formatInt(0.1*amount)}</p>) : null}
-            {isConsumable && allowMultiConsume? (<p>Right click + SHIFT to consume all</p>) : null}
-        </div> }>
-            <div className={'icon-content'}>
-                <CircularProgress progress={cooldownProg}>
-                    <img src={`icons/resources/${id}.png`} className={'resource'} />
-                </CircularProgress>
-                <span className={'level'}>{formatValue(amount)}</span>
-            </div>
-        </TippyWrapper>
-
-    </div> )
-}, ((prevProps, currProps) => {
-    if(prevProps.id !== currProps.id) {
-        return false;
-    }
-
-    if(prevProps.amount !== currProps.amount) {
-        return false;
-    }
-
-    if(prevProps.eta !== currProps.eta && (currProps.eta < 0 || prevProps.eta < 0)) {
-        return false;
-    }
-
-    if(prevProps.cooldownProg !== currProps.cooldownProg) {
-        return false;
-    }
-
-    if(prevProps.isConsumed !== currProps.isConsumed) {
-        return false;
-    }
-
-    if(prevProps.isChanged !== currProps.isChanged) {
-        return false;
-    }
-
-    if(prevProps.isSelected !== currProps.isSelected) {
-        return false;
-    }
-    return true;
-}))
-
-export const InventoryDetails = React.memo(({isChanged, editData, viewedData, resources, onAddAutoconsumeRule, onSetAutoconsumeRuleValue, onDeleteAutoconsumeRule, onAddAutosellRule, onSetAutosellRuleValue, onDeleteAutosellRule, onSave, onCancel, onSell, onSetAutosellPattern, onSetAutoconsumePattern, onSetAutosellReserved, onSetAutoconsumeReserved, onToggleAutoconsume, onToggleAutosell, automationUnlocked, onConsume, onTogglePinned, onToggleViewLasting}) => {
-
-    const worker = useContext(WorkerContext);
-
-    const { sendData, onMessage, removeMessage } = useWorkerClient(worker);
-
-    const { stepIndex, unlockNextById, jumpOver, currentTourId } = useTutorial();
-
-    const [details, setDetails] = useState(null);
-
-    const item = viewedData ? viewedData : editData;
-
-    let isEditing = !!editData && !viewedData;
-
-    if(!item) return null;
-
-    useEffect(() => {
-
-        if(item) {
-            sendData('query-inventory-details', { id: item.id, prefix: 'detail-blade' })
-        }
-    }, [item]);
-
-    useEffect(() => {
-        if(currentTourId === 'inventory' && details?.id === 'inventory_brightleaf') {
-            unlockNextById(14);
-        }
-    }, [details?.numConsumed, details?.currentDuration]);
-
-    useEffect(() => {
-        onMessage('detail-blade-inventory-details', (data) => {
-            setDetails(data);
-        });
-        
-        return () => {
-            removeMessage('detail-blade-inventory-details');
-        };
-    }, []);
-
-    const setAutoconsumePattern = (pattern) => {
-      onSetAutoconsumePattern(pattern)
-    }
-
-    const addAutoconsumeRule = () => {
-        onAddAutoconsumeRule()
-    }
-
-    const setAutoconsumeRuleValue = (index, key, value) => {
-        onSetAutoconsumeRuleValue(index, key, value)
-    }
-
-    const deleteAutoconsumeRule = (index) => {
-        onDeleteAutoconsumeRule(index)
-    }
-
-    const setAutosellPattern = (pattern) => {
-        onSetAutosellPattern(pattern)
-    }
-
-    const addAutosellRule = () => {
-        onAddAutosellRule()
-    }
-
-    const setAutosellRuleValue = (index, key, value) => {
-        onSetAutosellRuleValue(index, key, value)
-    }
-
-    const deleteAutosellRule = (index) => {
-        onDeleteAutosellRule(index)
-    }
-
-    const setReservedValue = (reserved) => {
-        onSetAutosellReserved(reserved)
-    }
-
-    const setReservedConsumeValue = (reserved) => {
-        onSetAutoconsumeReserved(reserved)
-    }
-
-    const toggleAutosell = () => {
-        onToggleAutosell()
-    }
-
-    const toggleAutoconsume = () => {
-        onToggleAutoconsume()
-    }
-
-    const consumeItem = () => {
-        if(currentTourId === 'inventory' && item.id === 'inventory_brightleaf') {
-            unlockNextById(14);
-        }
-        onConsume(item.id);
-    }
-
-    const togglePinned = () => {
-        onTogglePinned(item.id, !(details || item).isPinned);
-    }
-
-    const toggleViewLasting = () => {
-        onToggleViewLasting(item.id, !(details || item).show_lasting);
-    }
-
-    if(currentTourId === 'inventory' && item.id === 'inventory_brightleaf' && isEditing) {
-        unlockNextById(11);
-    }
-
-    return (
-        <>
-            <div className={'blade-outer'}>
-                <PerfectScrollbar>
-                    <div className={'blade-inner inventory-items-blade'}>
-                        <div className={'block'}>
-                            <div className={'inner-heading flex-container flex-row'}>
-                                <h4>{item.name} (x{formatInt(item.amount)})</h4>
-                                <PinResource id={item.id} isPinned={details?.isPinned} />
-                            </div>
-
-                            <div className={'description'}>
-                                {item.description}
-                            </div>
-                        </div>
-                        <div className={'block'}>
-                            <div className={'tags-container'}>
-                                {item.tags.map(tag => (<div key={tag} className={'tag'}>{tag}</div> ))}
-                            </div>
-                        </div>
-                        {item?.effects?.length ? (<div className={'block'}>
-                            <p>Effects on usage:</p>
-                            <div className={'effects'}>
-                                <EffectsSection effects={item.effects}/>
-                            </div>
-                        </div>) : null}
-                        {item.potentialPermanentEffects ? (<div className={'block'}>
-                            <p>Permanent Effects:</p>
-                            <div className={'effects'}>
-                                <ResourceComparison effects1={item.permanentEffects} effects2={item.potentialPermanentEffects}/>
-                            </div>
-                        </div>) : null}
-                        {item.duration ? (<div className={'block'}>
-                            <p>Effects lasting: {secondsToString(item.duration)}</p>
-                            <div className={'effects'}>
-                                <EffectsSection effects={item.potentialEffects} />
-                            </div>
-                            {item.canShowLasting ? (<div className={'show-lasting'}>
-                                <CustomButton
-                                    iconId={'icon_view_lasting'}
-                                    className={`toggle-effect-monitor medium-sm ${details?.show_lasting ? 'highlighted' : ''}`}
-                                    onClick={(e) => {toggleViewLasting()}}
-                                >{details?.show_lasting ? 'Stop showing active effects in left sidebar' : 'Show when active in left sidebar'}</CustomButton>
-                            </div> ) : null}
-                        </div>) : null}
-
-                        <div className={'block'}>
-                            {item.isConsumable ? (<div className={'flex-container consumption-block'}>
-                                <div className={'stats'}>
-                                    <p>Consumption Cooldown: {secondsToString(item.consumptionCooldown)}</p>
-                                    <p>Consumed amount: {formatInt(item.numConsumed)}</p>
-                                </div>
-                                <div className={'consume-block'}>
-                                    <button className={'consume-button'} onClick={consumeItem} disabled={details?.currentCooldown > 0 || details?.currentDuration > 0}>Consume</button>
-                                    {details?.currentDuration ? (<p className={'small'}>Running: {secondsToString(details?.currentDuration)}</p>) : null}
-                                    {details?.currentCooldown ? (<p className={'small'}>Cooldown: {secondsToString(details?.currentCooldown)}</p>) : null}
-                                </div>
-                            </div>) : null}
-                            {item.isSellable ? (<div>
-                                <p>Sold amount: {formatInt(item.soldAmount)}</p>
-                                <p>Coins Earned: {formatInt(item.coinsEarned)}</p>
-                            </div>) : null}
-                        </div>
-
-                        {item.isConsumable && automationUnlocked ? (<div className={'autoconsume-setting block'}>
-                            <div className={'rules-header flex-container'}>
-                                <p>Autoconsumption rules: {item.autoconsume?.rules?.length ? null : 'None'}</p>
-                                <label>
-                                    <input type={'checkbox'} checked={item.autoconsume?.isEnabled ?? undefined} onChange={toggleAutoconsume}/>
-                                    {item.autoconsume?.isEnabled ? ' ON' : ' OFF'}
-                                </label>
-                                {isEditing ? (<button onClick={addAutoconsumeRule}>Add rule (AND)</button>) : null}
-                            </div>
-
-                            <RulesList
-                                prefix={'autoconsume'}
-                                isEditing={isEditing}
-                                rules={item.autoconsume?.rules || []}
-                                resources={resources}
-                                pattern={item.autoconsume?.pattern}
-                                deleteRule={deleteAutoconsumeRule}
-                                setRuleValue={setAutoconsumeRuleValue}
-                                setPattern={setAutoconsumePattern}
-                                isAutoCheck={item.autoconsume?.isEnabled}
-                            />
-                            <div className={'autoconsume-amount flex-container'}>
-                                <p>Reserved Amount:</p>
-                                {isEditing ? <input type={'number'} onChange={e => setReservedConsumeValue(+e.target.value)}
-                                        value={item.autoconsume?.reserved || 0}/> : <span>{formatValue(item.autoconsume?.reserved || 0)}</span>}
-                            </div>
-                        </div>) : null}
-
-                        {item.isSellable && automationUnlocked ? (<div className={'autoconsume-setting block'}>
-                            <div className={'rules-header flex-container'}>
-                                <p>Autosell rules: {item.autosell?.rules?.length ? null : 'None'}</p>
-                                <label>
-                                    <input type={'checkbox'} checked={item.autosell?.isEnabled ?? undefined} onChange={toggleAutosell}/>
-                                    {item.autosell?.isEnabled ? ' ON' : ' OFF'}
-                                </label>
-                                {isEditing ? (<button onClick={addAutosellRule}>Add rule (AND)</button>) : null}
-                            </div>
-
-                            <RulesList
-                                prefix={'autosell'}
-                                isEditing={isEditing}
-                                rules={item.autosell?.rules || []}
-                                pattern={item.autosell?.pattern}
-                                resources={resources}
-                                deleteRule={deleteAutosellRule}
-                                setRuleValue={setAutosellRuleValue}
-                                setPattern={setAutosellPattern}
-                                isAutoCheck={item.autosell?.isEnabled}
-                            />
-                            <div className={'autosell-amount flex-container'}>
-                                <p>Reserved Amount:</p>
-                                {isEditing ? <input type={'number'} onChange={e => setReservedValue(+e.target.value)}
-                                        value={item.autosell?.reserved || 0}/> : <span>{formatValue(item.autosell?.reserved || 0)}</span>}
-                            </div>
-                        </div>) : null}
-
-                        {item.isSellable ? (<div className={'block sell-block'}>
-                            <p className={'text-desc'}>Sell price: {formatValue(item.sellPrice)}</p>
-                            <div className={'buttons flex-container'}>
-                                <button disabled={item.maxSell < 1} onClick={() => onSell(item.id, 1)}>Sell</button>
-                                <button disabled={item.maxSell < 1} onClick={() => onSell(item.id, item.maxSell)}>Sell max (x{formatInt(item.maxSell)})</button>
-                            </div>
-                        </div> ) : null}
-
-
-                    </div>
-                </PerfectScrollbar>
-            </div>
-            {isEditing ? (<div className={'buttons flex-container main-buttons'}>
-                <button className={'primary-action'} disabled={!isChanged} onClick={onSave}>Save</button>
-                {/*<TippyWrapper content={<div className={'hint-popup'}>Pinning item will make it visible at resources panel</div> }>
-                    <button onClick={togglePinned}>{details?.isPinned ? 'Unpin' : 'Pin'}</button>
-                </TippyWrapper>*/}
-                <button className={'warning-action'} onClick={onCancel}>Cancel</button>
-            </div>) : null}
-        </>
-    )
-}, (prevProps, currentProps) => {
-
-    if(prevProps.isChanged !== currentProps.isChanged) {
-        return false;
-    }
-
-    if(prevProps.editData !== currentProps.editData) {
-        return false;
-    }
-
-    if(prevProps.viewedData !== currentProps.viewedData) {
-        return false;
-    }
-
-    return true;
-})
-
-export const InventoryStats = ({ details, setDetailVisible }) => {
-
-    const { isMobile } = useAppContext();
-    // Масив статистик, які потрібно відобразити
-    const statsToDisplay = [
-        /*details.metabolism_rate,
-        details.cooldown_bonus,*/
-        details.bargaining,
-        details.bargaining_mod,
-        details.shop_max_stock,
-        details.shop_stock_renew_rate,
-        // Додайте інші статистики за потребою
-    ];
-
-    const hasEffect = useCallback((stat) => {
-        if(!stat?.value) return false;
-        return !stat.isMultiplier || Math.abs(stat?.value - 1.0) > 1.e-7;
-    }, [])
-
-    return (
-        <PerfectScrollbar>
-            <div className={'blade-inner'}>
-                <div className={'block'}>
-                    <p>General Stats:</p>
-                    <div className={'effects'}>
-                        {statsToDisplay.map((stat) => (
-                            hasEffect(stat) ? (
-                                <StatRow key={stat.id} stat={stat} />
-                            ) : null
-                        ))}
-                    </div>
-                </div>
-                {isMobile ? (<div className={'block buttons'}>
-                    <button onClick={() => setDetailVisible(false)}>Close</button>
-                </div>) : null}
-            </div>
-        </PerfectScrollbar>
-    );
-};

--- a/src/state/inventory-store.js
+++ b/src/state/inventory-store.js
@@ -1,0 +1,233 @@
+import {useEffect, useRef, useState} from 'react';
+
+const isPlainObject = (value) => {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+};
+
+const mergeValue = (previous, next) => {
+    if (Object.is(previous, next)) {
+        return previous;
+    }
+
+    if (Array.isArray(next)) {
+        return mergeArray(Array.isArray(previous) ? previous : undefined, next);
+    }
+
+    if (isPlainObject(next)) {
+        return mergeObject(isPlainObject(previous) ? previous : undefined, next);
+    }
+
+    return next;
+};
+
+const mergeObject = (previous = {}, next = {}) => {
+    if (Object.is(previous, next)) {
+        return previous;
+    }
+
+    let hasChanges = false;
+    const merged = {};
+    const nextKeys = Object.keys(next);
+
+    for (const key of nextKeys) {
+        const mergedValue = mergeValue(previous?.[key], next[key]);
+        merged[key] = mergedValue;
+
+        if (!Object.is(mergedValue, previous?.[key])) {
+            hasChanges = true;
+        }
+    }
+
+    if (!hasChanges && Object.keys(previous ?? {}).length === nextKeys.length) {
+        return previous;
+    }
+
+    return merged;
+};
+
+const getItemKey = (value) => {
+    if (!value || typeof value !== 'object') {
+        return undefined;
+    }
+
+    if ('id' in value) return value.id;
+    if ('key' in value) return value.key;
+    if ('uid' in value) return value.uid;
+    if ('slug' in value) return value.slug;
+    if ('name' in value) return value.name;
+
+    return undefined;
+};
+
+const mergeArray = (previous = [], next = []) => {
+    if (Object.is(previous, next)) {
+        return previous;
+    }
+
+    if (!Array.isArray(next)) {
+        return next;
+    }
+
+    const hadPrevious = Array.isArray(previous);
+    let hasChanges = !hadPrevious || previous.length !== next.length;
+    const merged = new Array(next.length);
+    const previousByKey = new Map();
+
+    if (hadPrevious) {
+        for (const item of previous) {
+            const key = getItemKey(item);
+            if (key !== undefined && !previousByKey.has(key)) {
+                previousByKey.set(key, item);
+            }
+        }
+    }
+
+    for (let index = 0; index < next.length; index += 1) {
+        const nextValue = next[index];
+        const key = getItemKey(nextValue);
+        const fallbackPrev = hadPrevious ? previous[index] : undefined;
+        const matchedPrev = key !== undefined && previousByKey.has(key)
+            ? previousByKey.get(key)
+            : fallbackPrev;
+        const value = mergeValue(matchedPrev, nextValue);
+        merged[index] = value;
+
+        if (!hadPrevious || !Object.is(value, fallbackPrev)) {
+            hasChanges = true;
+        }
+    }
+
+    if (!hasChanges && hadPrevious) {
+        return previous;
+    }
+
+    return merged;
+};
+
+const defaultState = {
+    available: [],
+    current: undefined,
+    itemCategories: [],
+    selectedFilterId: 'all',
+    automationUnlocked: false,
+    details: {},
+    searchData: {
+        search: '',
+        selectedScopes: ['name', 'tags'],
+    },
+};
+
+let state = defaultState;
+const listeners = new Set();
+
+const getSnapshot = () => state;
+
+const emitChange = () => {
+    listeners.forEach(listener => listener());
+};
+
+export const subscribeInventoryStore = (listener) => {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+};
+
+export const getInventorySnapshot = () => state;
+
+export const updateInventoryState = (partialState = {}) => {
+    if (!partialState || typeof partialState !== 'object') {
+        return;
+    }
+
+    const prevState = state;
+    let hasChanges = false;
+    const nextState = { ...prevState };
+
+    for (const [key, value] of Object.entries(partialState)) {
+        const mergedValue = mergeValue(prevState[key], value);
+
+        if (!Object.is(prevState[key], mergedValue)) {
+            nextState[key] = mergedValue;
+            hasChanges = true;
+        }
+    }
+
+    if (!hasChanges) {
+        return;
+    }
+
+    state = nextState;
+    emitChange();
+};
+
+export const resetInventoryState = () => {
+    state = defaultState;
+    emitChange();
+};
+
+const identity = (value) => value;
+
+const ensureSelector = (selector) => {
+    if (typeof selector === 'function') {
+        return selector;
+    }
+
+    return identity;
+};
+
+const ensureEqualityFn = (isEqual) => {
+    if (typeof isEqual === 'function') {
+        return isEqual;
+    }
+
+    return Object.is;
+};
+
+export const useInventoryData = (selector = identity, isEqual = Object.is) => {
+    const latestSelectionRef = useRef();
+    const selectorRef = useRef(() => state);
+    const equalityFnRef = useRef(Object.is);
+
+    selectorRef.current = ensureSelector(selector);
+    equalityFnRef.current = ensureEqualityFn(isEqual);
+
+    const [selection, setSelection] = useState(() => {
+        const currentSelector = selectorRef.current;
+        const value = currentSelector(getSnapshot());
+        latestSelectionRef.current = value;
+        return value;
+    });
+
+    useEffect(() => {
+        const nextSelection = selectorRef.current(getSnapshot());
+        if (!equalityFnRef.current(latestSelectionRef.current, nextSelection)) {
+            latestSelectionRef.current = nextSelection;
+            setSelection(nextSelection);
+        }
+    }, [selector, isEqual]);
+
+    useEffect(() => {
+        const handleChange = () => {
+            const nextSelection = selectorRef.current(getSnapshot());
+            if (!equalityFnRef.current(latestSelectionRef.current, nextSelection)) {
+                latestSelectionRef.current = nextSelection;
+                setSelection(nextSelection);
+            }
+        };
+
+        const unsubscribe = subscribeInventoryStore(handleChange);
+        return () => {
+            unsubscribe?.();
+        };
+    }, []);
+
+    return selection;
+};
+
+export const getDefaultInventoryState = () => defaultState;


### PR DESCRIPTION
## Summary
- reuse existing inventory items, categories, and stats when worker payloads do not meaningfully change so we avoid unnecessary rerenders
- memoize handlers and the rendered inventory/category lists so the tab no longer rebuilds dozens of cards on unrelated state updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b144750c8320b83b3d9d27026bed)