### PR TITLE
Add Ctrl modifier to toggle XP breakdown details

### DIFF
--- a/src/components/actions/action-xp-breakdown.jsx
+++ b/src/components/actions/action-xp-breakdown.jsx
@@ -14,6 +14,7 @@ export const ActionXPBreakdown = ({ id }) => {
         total: 0,
         nextEtas: {}
     });
+    const [isCtrlPressed, setIsCtrlPressed] = useState(false);
 
     // const [filterId, setFilterId] = useState('all');
 
@@ -32,19 +33,44 @@ export const ActionXPBreakdown = ({ id }) => {
         onMessage(`action-xp-breakdown-${id}`, breakdowns => {
             setBreakdowns(breakdowns);
         });
-        
+
         return () => {
             removeMessage(`action-xp-breakdown-${id}`);
         };
     }, [id]);
 
+    useEffect(() => {
+        const handleKeyDown = (event) => {
+            if(event.key === 'Control') {
+                setIsCtrlPressed(true);
+            }
+        };
+
+        const handleKeyUp = (event) => {
+            if(event.key === 'Control' || !event.ctrlKey) {
+                setIsCtrlPressed(false);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        window.addEventListener('keyup', handleKeyUp);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            window.removeEventListener('keyup', handleKeyUp);
+        };
+    }, []);
+
     return (<div className={'hint-popup breakdowns'}>
+        {!isCtrlPressed ? (<p className={'hint ctrl-hint'}>Hit Ctrl to see more details</p>) : null}
         {breakdowns.breakDowns && Object.values(breakdowns.breakDowns).length ? (
             Object.values(breakdowns.breakDowns).map(breakDown => (<div key={breakDown.title} className={'breakdown-section'}>
                 <p className={'semi-title'}>{breakDown.title}: {breakDown.isPlain ? '+' : 'X'}{formatValue(breakDown.value)}</p>
-                <div className={'breakdown-section-sub'}>
-                    <BreakDown breakDown={breakDown.breakDown} />
-                </div>
+                {isCtrlPressed && breakDown.breakDown ? (
+                    <div className={'breakdown-section-sub'}>
+                        <BreakDown breakDown={breakDown.breakDown} />
+                    </div>
+                ) : null}
             </div> ))
         ) : null}
         <div className={'block etas-milestones'}>


### PR DESCRIPTION
## Summary
- add a Ctrl key listener to the action XP breakdown tooltip so that the detailed effect list is hidden by default
- show a hint explaining how to reveal the full breakdown and only render nested details when Ctrl is pressed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919141800ac8320baf1253158365f96)